### PR TITLE
Add full schedule as a top button

### DIFF
--- a/_includes/partials/content/staking-gathering-top-buttons-2023.html
+++ b/_includes/partials/content/staking-gathering-top-buttons-2023.html
@@ -1,0 +1,11 @@
+
+<p class="text-center">
+  {% include partials/components/button.html
+    link="https://ticketh.xyz/ethstaker/devconnect/"
+    text="Buy Tickets"
+  %}
+  {% include partials/components/button.html
+    link="https://stakinggathering2023.sched.com/"
+    text="Full Schedule"
+  %}
+</p>

--- a/staking-gathering-2023.md
+++ b/staking-gathering-2023.md
@@ -13,11 +13,7 @@ buttons:
   text: For volunteers
 ---
 
-{:class="text-center"}
-{% include partials/components/button.html
-  link="https://ticketh.xyz/ethstaker/devconnect/"
-  text="Buy Tickets"
-%}
+{% include partials/content/staking-gathering-top-buttons-2023.html %}
 
 ## Welcome to the Staking Gathering at Devconnect Conference!
 


### PR DESCRIPTION
Simply adding a link to the full schedule at the top of the staking gathering page for quick access.