### PR TITLE
feature/add-withdrawal-address-note

### DIFF
--- a/airdrops.md
+++ b/airdrops.md
@@ -31,7 +31,7 @@ Providing Airdrops to Solo and Home stakers is an excellent way to engage the di
 - Communicate with the staking community to let them know why you chose to airdrop to them! Even if it's just a "thank you", or if you want to encourage them to take some action
 - Allow "claiming on behalf of another address". This means paying for the smart contract cost with a different wallet than the recipient. Many home stakers are EXTREMELY cautious with any keys related to staking, and they'd prefer not to connect those to the network if at all possible. This is doubly beneficial because it means more stakers will hold onto the tokens for longer!
 - Refer to published lists of home stakers like the list maintained by [GLCStaked](https://github.com/GLCNI/ETH-Solo-Validator-Addresses) and the list by [rated.network](https://github.com/rated-network/solo-stakers/tree/main) and rather than developing your own list. This prevents confusion and gives you as the airdropper a direction to refer complaints rather than dealing with frustrated users
-
+- Use the withdrawal address of the validator, most deposit addresses for solo validator are throw away addresses
  
 ### Don'ts
 


### PR DESCRIPTION
Add a comment on withdrawal address, many solo validator were not eligible on the Omni aidrop.

Deposit address created in 2020 could not use hardware wallet, we used throw away address, mostly metamask, that are either compromised, or lost.