### PR TITLE
Update hardware.yml - add guide for BIOS menu auto-on

### DIFF
--- a/_data/hardware.yml
+++ b/_data/hardware.yml
@@ -47,7 +47,7 @@
       price: 10
   usage: optional
   min_specs: 
-  guide:
+  guide: https://www.wintips.org/setup-computer-to-auto-power-on-after-power-outage/
 - name: Computer
   index: 3
   products: 


### PR DESCRIPTION
smart plug requires the setting in the BIOS menu to default to an ON state upon detecting power