### PR TITLE
Updated ENS and twitter references from armagan.eth to dirtynode.eth

### DIFF
--- a/rhino-review.md
+++ b/rhino-review.md
@@ -4,15 +4,13 @@ title: Rhino Review
 permalink: /rhino-review
 
 buttons:
-- link: 'https://rhinoreview.substack.com/'
-  text: View on Substack
+  - link: "https://rhinoreview.substack.com/"
+    text: View on Substack
 ---
 
-Rhino Review is a bi-weekly Ethereum staking journal that compiles the most recent updates on the Ethereum Proof of Stake network, DVT, LSD, and at-home staker community. This is an initiative lead by [armagan.eth](https://twitter.com/0xarmagan). If you want to support this effort you can [purchase his POAP](https://checkout.poap.xyz/sale/c29feed2-3660-4c5f-a59f-cb0e02e2406d) or donate to [armagan.eth](https://etherscan.io/address/armagan.eth).
-
+Rhino Review is a bi-weekly Ethereum staking journal that compiles the most recent updates on the Ethereum Proof of Stake network, DVT, LSD, and at-home staker community. This is an initiative lead by [dirtynodes](https://x.com/dirtynodes). If you want to support this effort you can donate to [dirtynode.eth](https://etherscan.io/address/dirtynode.eth).
 
 {% include partials/embeds/substack-rhino-review.html %}
-
 
 {: class="text-center mt-3"}
 [View on Substack](https://rhinoreview.substack.com/)


### PR DESCRIPTION
Updating the ENS from armagan.eth to dirtynode.eth and the twitter account from username armagan to dirtynodes. This is all per a request that Armagan sent via DM to update this info as he has been using these names for the last 6-7 months.

Note: there is intentionally an "s" included at the end of the twitter username, but that is not present in the ENS name.