### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Resources:
 - `_includes` - This folder is [designated by Jekyll](https://jekyllrb.com/docs/includes/) for files that can be "included" into other files
     - `js` - Contains javascript files, most of which are compiled in `assets/js/main.js`
     - `partials`
-        - `components` - Contains reusable non-content components, including the thml head, nav, and footer
+        - `components` - Contains reusable non-content components, including the html head, nav, and footer
         - `content` - Contains sections of html content
         - `embeds` - Contains embed content
     - `tools` - Contains include-based tools


### PR DESCRIPTION
#### Details of the Fix:  

<img width="836" alt="Снимок экрана 2024-11-30 в 15 39 13" src="https://github.com/user-attachments/assets/98b9e7e0-ea42-4454-ad69-ea320b6c3092">

- The word **"thml"** was incorrectly used instead of **"html"** in the description of reusable components under `_includes`.  
- Corrected sentence:  
  **"...reusable non-content components, including the html head, nav, and footer."**  

#### Why This Matters:  
Clear and accurate documentation is essential for developers to navigate and understand the project. Fixing this typo ensures that the text is both professional and easy to comprehend.  

Thank you for reviewing this update!