### PR TITLE
add a card for Lido CSM in Staking Pool Node Operator section

### DIFF
--- a/_includes/partials/content/staking/node-op.html
+++ b/_includes/partials/content/staking/node-op.html
@@ -132,9 +132,8 @@
                 <li><a href="https://docs.lido.fi/run-on-lido/csm/">Guides</a></li>
                 <li><a href="https://discord.com/invite/lido">Discord</a></li>
                 <li><a href="https://github.com/lidofinance/audits">Audits</a></li>
-                <li>1.3 - 2.4 ETH as collateral requirement</li>
-                <li>Dual rewards: commission + collateral rebase</li>
-                <li>Better terms for independent stakers</li>
+                <li>Requires 1.3 - 2.4 ETH collateral</li>
+                <li>Earns 3.5% - 6% commission on pool</li>
               </ul>
             </div>
             <a href="https://operatorportal.lido.fi/modules/community-staking-module" class="btn btn-outline-dark btn-sm shadow-sm w-100 new-tab" target="_blank">Learn more</a>

--- a/_includes/partials/content/staking/node-op.html
+++ b/_includes/partials/content/staking/node-op.html
@@ -120,6 +120,27 @@
           </div>
         </div>
       </div>
+      <div class="col col-12 col-md-6 col-xl-4 d-flex align-items-stretch mb-3">
+        <div class="card shadow border-light w-100">
+          <div class="card-body d-flex align-items-start flex-column">
+            <h5 class="card-title">Lido CSM</h5>
+            <span class="badge rounded-pill text-bg-primary mb-2">Recommended</span>
+            <div class="card-text mb-auto mt-2">
+              <p>Lido CSM is recommended on this list due to it being permissionless and healthiest for the network, which strengthens your own investment.</p>
+              <ul class="mb-auto">
+                <li><a href="https://csm.lido.fi/">Official website</a></li>
+                <li><a href="https://docs.lido.fi/run-on-lido/csm/">Guides</a></li>
+                <li><a href="https://discord.com/invite/lido">Discord</a></li>
+                <li><a href="https://github.com/lidofinance/audits">Audits</a></li>
+                <li>1.3 - 2.4 ETH as collateral requirement</li>
+                <li>Dual rewards: commission + collateral rebase</li>
+                <li>Better terms for independent stakers</li>
+              </ul>
+            </div>
+            <a href="https://operatorportal.lido.fi/modules/community-staking-module" class="btn btn-outline-dark btn-sm shadow-sm w-100 new-tab" target="_blank">Learn more</a>
+          </div>
+        </div>
+      </div>
     </div>
     {%- comment -%}
     <!-- Resources -->


### PR DESCRIPTION
I see CSM has been displayed as an example of Pool NO in the 'Exploer staking Methods' section in the staking page but there is no card to show CSM details in staking pool NO section so I would like to propose a suggestion by adding a card including links and features of Lido CSM.
