### PR TITLE
Update CoinCashew guide link to EthPillar

### DIFF
--- a/_data/solo-staking-guides.yml
+++ b/_data/solo-staking-guides.yml
@@ -32,7 +32,7 @@
 - title: CoinCashew Guides
   img: "/assets/img/solo-staking-guides/coincashew.png"
   description: Build your own hardware and copy/paste CLI commands.
-  link: "https://docs.coincashew.com"
+  link: "https://ethpillar.coincashew.io/"
 - title: Stakesaurus Guides
   img: "/assets/img/solo-staking-guides/stakesaurus.png"
   description: Build your own hardware and copy/paste CLI commands.


### PR DESCRIPTION
Points the **CoinCashew Guides** card on [/solo-staking-guides](https://ethstaker.org/solo-staking-guides) at the EthPillar docs.

- Before: `https://docs.coincashew.com`
- After: `https://ethpillar.coincashew.io/`

Single-line change in `_data/solo-staking-guides.yml`, which is what the card on that page renders from. Target URL verified live (HTTP 200, no redirect).

Note: other CoinCashew links elsewhere in the repo (`_data/staking-software.yml`, `_data/resources.yml`, `_includes/partials/content/staking/solo.html`, `solo-staking-guides/_coincashew.md`) were left untouched — this change is scoped to the solo staking guides page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)