### PR TITLE
Align site with the EthCoordinate design system

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the source code for EthStaker's website, <https://ethstaker.org>.
 **Table of Contents**
 
 - [Local Development](#local-development)
+- [Theme](#theme)
 - [Directory Structure](#directory-structure)
 - [Editing Existing Content](#editing-existing-content)
     - [Adding Resources](#adding-resources)
@@ -40,6 +41,13 @@ Resources:
 - [Jekyll Docs](https://jekyllrb.com/docs/)
 - [Liquid Syntax](https://shopify.github.io/liquid/basics/introduction/)
 
+
+
+## Theme
+
+The site shares the [EthCoordinate](https://ethcoordinate.org) design system: JetBrains Mono, cyan/purple accents on a near-black background, and a matching light palette. Everything lives in `assets/css/main.css` (tokens, Bootstrap variable remaps, nav, hero, footer, components) and `assets/css/markdown.css` (long-form content). Bootstrap 5 still handles layout, so existing utility classes and partials keep working.
+
+Dark mode is the default unless the OS prefers light or the visitor toggles the theme; the choice is stored in `localStorage` (`darkModeEnabled`) and applied before first paint by the inline script in `_includes/partials/components/head.html`.
 
 
 ## Directory Structure

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -4,7 +4,7 @@ environment: development
 enable_getdate: false # gets the publish/update date of resource links
 
 # Notification Bar
-enable_notification: true
+enable_notification: false
 notification_msg_id: 1 # must increment when creating a new message
 notification_msg: <a href="http://dsc.gg/ethstaker">Join the community!</a>
 notification_expiration: 3000000000 # epoch time in seconds

--- a/_includes/js/aos.js
+++ b/_includes/js/aos.js
@@ -2,7 +2,7 @@
 // https://michalsnik.github.io/aos/
 // - Initializes library
 // - Dynamically add fade in animations to content
-//   this is done dynamically so the content will 
+//   this is done dynamically so the content will
 //   still show if the user has javascript disabled
 
 // Usage:
@@ -15,6 +15,8 @@ const aosSelectors = [
   "body > header",
   "body > section",
   "body > footer",
+  "main > header",
+  "main > section",
   // "table",
   // ".markdown-aos > h1",
   // ".markdown-aos > h2",
@@ -47,7 +49,7 @@ document.querySelectorAll(".aos-left")
 AOS.init({
   // Global settings:
   disable: false, // accepts following values: 'phone', 'tablet', 'mobile', boolean, expression or function
-  
+
   // Settings that can be overridden on per-element basis, by `data-aos-*` attributes:
   offset: 120, // offset (in px) from the original trigger point
   delay: 50, // values from 0 to 3000, with step 50ms

--- a/_includes/js/updateLinkTargets.js
+++ b/_includes/js/updateLinkTargets.js
@@ -25,6 +25,11 @@ function updateLinkTargets() {
       links[link].target = "_self";
       links[link].classList.remove("new-tab");
     }
+    // same-origin links are internal on any host (localhost, deploy previews)
+    if (href != undefined && window.location.host != "" && href.includes("//" + window.location.host)) {
+      links[link].target = "_self";
+      links[link].classList.remove("new-tab");
+    }
     // The above condition should catch this, but leaving it here in case it needs to be stated explicitely
     // if ( (href != undefined && href[0] == "#") || (href != undefined && href[0] == "/") ) {
     //   links[link].target = "_self";

--- a/_includes/partials/components/contribute.html
+++ b/_includes/partials/components/contribute.html
@@ -1,43 +1,14 @@
 {%- comment -%}
-<!-- 
+<!--
 Add to config.yml:
 # Contribute/Edit CTA
 enable_contribute_cta: true
+
+Styles live in assets/css/main.css (#contributeCTA).
 -->
 {%- endcomment -%}
 
 {%- if site.enable_contribute_cta == true -%}
-<style type="text/css">
-  #contributeCTA {
-    position: fixed;
-    z-index: 100;
-    bottom: 2rem;
-    right: 1.5rem;
-    /*font-size: 0.85rem;*/
-    box-shadow: 0rem 0.25rem 1rem rgba(0,0,0,0.3);
-  }
-  #contributeCTA span {
-    display: none;
-  }
-  #contributeCTA svg {
-    font-size: 1.25rem;
-  }
-  @media only screen and (max-width: 767px) {
-    #contributeCTA {
-      position: fixed;
-      z-index: 100;
-      bottom: 1rem;
-      right: 1rem;
-      font-size: 0.85rem;
-      box-shadow: 0rem 0.25rem 1rem rgba(0,0,0,0.3);
-    }
-    #contributeCTA svg {
-      font-size: 1rem;
-    }
-  }
-</style>
-
-
 <!-- Contribute CTA -->
 <a id="contributeCTA" class="btn btn-light rounded-pill small" href="https://github.com/ethstaker/website/blob/main/{{page.path}}" target="_blank">
   {{site.data.icons.github}} Edit Page

--- a/_includes/partials/components/dark-mode-toggle.html
+++ b/_includes/partials/components/dark-mode-toggle.html
@@ -1,90 +1,61 @@
 {%- comment -%}
-<!-- 
-Adds a dark mode theme. 
-Defaults to system preference and overridden by manual toggle.
-Adds a .dark-mode class to html element.
+<!--
+Dark / light theme toggle.
+Defaults to dark (matching ethcoordinate.org) unless the OS prefers light
+or the visitor previously picked a theme. The inline script in head.html
+applies the same rule before first paint; this include only keeps the
+button state in sync and stores an explicit choice.
+Sets data-bs-theme on <html> plus a .dark-mode class for legacy selectors.
 -->
 {%- endcomment -%}
 
-<style type="text/css">
-  #darkModeToggle {
-    padding: 5px;
-    cursor: pointer;
-    margin-right: -2rem;
-    margin-left: 1.5rem;
-  }
-  @media only screen and (max-width: 1399px) {
-    #darkModeToggle {
-      margin-right: -1.5rem;
-    }
-  }
-  @media only screen and (max-width: 1199px) {
-    #darkModeToggle {
-      margin-right: -0.75rem;
-    }
-  }
-  @media only screen and (max-width: 991px) {
-    #darkModeToggle {
-      margin-right: 1rem;
-      margin-left: auto!important;
-    }
-  }
-  #darkModeToggle svg {
-    height: 1.5rem;
-    width: 1.5rem;
-  }
-  .d-dark,
-  .dark-mode .d-light {
-    display: none !important;
-  }
-  .d-light,
-  .dark-mode .d-dark {
-    display: unset !important;
-  }
-</style>
-
-
-<div id="darkModeToggle" class="">
-    <span id="enableDarkMode" onclick="setDarkMode('true')">{{site.data.icons.sun}}</span>
-    <span id="disableDarkMode" class="d-none" onclick="setDarkMode('false')">{{site.data.icons.sun}}</span>
+<div id="darkModeToggle">
+  <button type="button" id="enableDarkMode" class="d-none" onclick="setDarkMode('true')" aria-label="Switch to dark mode" title="Switch to dark mode">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+    </svg>
+  </button>
+  <button type="button" id="disableDarkMode" class="d-none" onclick="setDarkMode('false')" aria-label="Switch to light mode" title="Switch to light mode">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="5"></circle>
+      <line x1="12" y1="1" x2="12" y2="3"></line>
+      <line x1="12" y1="21" x2="12" y2="23"></line>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+      <line x1="1" y1="12" x2="3" y2="12"></line>
+      <line x1="21" y1="12" x2="23" y2="12"></line>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+  </button>
 </div>
 
 
 <script type="text/javascript">
   checkDarkMode();
-  
-  // Check if dark mode is set
+
+  // Apply the stored theme, or fall back to the OS preference (dark by default)
   function checkDarkMode() {
-    let darkModeEnabled = localStorage.getItem("darkModeEnabled");
-    if (darkModeEnabled === null) {
-      let matched = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      if(matched) {
-        setDarkMode("true");
-      } else {
-        setDarkMode("false");
-      }
+    let darkModeEnabled = null;
+    try { darkModeEnabled = localStorage.getItem("darkModeEnabled"); } catch (e) {}
+    if (darkModeEnabled === "true" || darkModeEnabled === "false") {
+      setDarkMode(darkModeEnabled, false);
     } else {
-      setDarkMode(darkModeEnabled);
+      let prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+      setDarkMode(prefersLight ? "false" : "true", false);
     }
   }
 
   // Toggle dark mode theme
-  function setDarkMode(enabled) {
-    document.getElementById("enableDarkMode").classList.add("d-none");
-    document.getElementById("disableDarkMode").classList.add("d-none");
-    var root = document.getElementsByTagName("html")[0];
-    if (enabled == "true") {
-      // log("Dark Mode enabled");
-      root.setAttribute("data-bs-theme", "dark"); 
-      root.classList.add("dark-mode");
-      document.getElementById("disableDarkMode").classList.remove("d-none");
-      localStorage.setItem("darkModeEnabled", "true");
-    } else if (enabled == "false") {
-      // log("Dark Mode disabled");
-      root.setAttribute("data-bs-theme", "light"); 
-      root.classList.remove("dark-mode");
-      document.getElementById("enableDarkMode").classList.remove("d-none");
-      localStorage.setItem("darkModeEnabled", "false");
+  function setDarkMode(enabled, persist = true) {
+    const root = document.documentElement;
+    const dark = enabled == "true";
+    root.setAttribute("data-bs-theme", dark ? "dark" : "light");
+    root.classList.toggle("dark-mode", dark);
+    document.getElementById("enableDarkMode").classList.toggle("d-none", dark);
+    document.getElementById("disableDarkMode").classList.toggle("d-none", !dark);
+    if (persist) {
+      try { localStorage.setItem("darkModeEnabled", dark ? "true" : "false"); } catch (e) {}
     }
   }
 </script>

--- a/_includes/partials/components/divider-icons-template.html
+++ b/_includes/partials/components/divider-icons-template.html
@@ -1,40 +1,23 @@
-<style type="text/css">
-  .divider-icons {
-    width: 100%;
-    max-width: 100%;
-  }
-  .divider-icons img,
-  .divider-icons svg {
-    height: 50px;
-    width: auto;
-    display: inline-block;
-    filter: brightness(0%) !important;
-    opacity: 0.15;
-  }
-  
-  .dark-mode .divider-icons img,
-  .dark-mode .divider-icons svg {
-    opacity: 0.25;
-    filter: contrast(0%) brightness(120%) sepia(100%) hue-rotate(175deg) grayscale(20%) !important;
-  }
-</style>
-
-
-<!-- Project Icons Divider -->
+<!-- Icons divider: a thin gradient rule with dimmed project logos, in the
+     style of the ethcoordinate.org section dividers. Styles live in main.css. -->
 <section class="{{include.class}} divider-icons overflow-hidden aos-up">
-  <div class="container my-5">
-    <div class="d-flex justify-content-center">
-      {% assign imgs = include.imgs | split: "," | trim %}
-      {%- for img in imgs -%}
-        {%- if img contains "site.data" -%}
-          {% assign img_path = img | replace: "site.data", "" | split: "." %}
-          {% assign img_file = img_path[1] %}
-          {% assign img_target = img_path[2] %}
-          <span class="mx-3 mx-lg-4">{{site.data[img_file][img_target]}}</span>
-        {%- else -%}
-          <img class="mx-3 mx-lg-4" src="{{img}}">
-        {%- endif -%}
-      {%- endfor -%}
+  <div class="container">
+    <div class="divider">
+      <div class="divider-line"></div>
+      <div class="divider-icons-row">
+        {% assign imgs = include.imgs | split: "," | trim %}
+        {%- for img in imgs -%}
+          {%- if img contains "site.data" -%}
+            {% assign img_path = img | replace: "site.data", "" | split: "." %}
+            {% assign img_file = img_path[1] %}
+            {% assign img_target = img_path[2] %}
+            <span>{{site.data[img_file][img_target]}}</span>
+          {%- else -%}
+            <img src="{{img}}" alt="" loading="lazy">
+          {%- endif -%}
+        {%- endfor -%}
+      </div>
+      <div class="divider-line"></div>
     </div>
   </div>
 </section>

--- a/_includes/partials/components/footer.html
+++ b/_includes/partials/components/footer.html
@@ -1,143 +1,80 @@
-{%- assign padding = "mt-5 pt-5" -%}
-{%- assign pages_without_padding = "index.md,staking.md" | split: "," -%}
-{%- if pages_without_padding contains page.name -%}
-  {%- assign padding = "" -%}
-{%- endif -%}
-
-
-<style type="text/css">
-  footer .disclaimer {
-    font-size: 0.85rem;
-  }
-
-  .dark-mode .link-dark {
-    color: var(--bs-gray-500) !important;
-  }
-</style>
-
-
-<footer class="{{padding}} aos-up" data-aos-anchor-placement="top-bottom" data-aos-offset="50">
+<footer class="site-footer aos-up" data-aos-anchor-placement="top-bottom" data-aos-offset="50">
   <div class="container">
-    <div class="py-5 border-top">
-      <div class="row">
-        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-3">
-          <h5>Intro</h5>
-          <ul class="nav flex-column">
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/about">About EthStaker</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/events">Events</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="https://docs.ethstaker.org/faq" target="_blank">FAQ</a></li>
-          </ul>
-        </div>
-
-        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-3">
-          <h5>Get Started</h5>
-          <ul class="nav flex-column">
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/safety">Safety</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/staking">Staking</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="https://docs.ethstaker.org/" target="_blank">Knowledge Base</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/solo-staking-guides">Guides</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/staking-hardware">Hardware</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/staking-software">Software</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/staking#staking-quiz">Staking Quiz</a></li>
-          </ul>
-        </div>
-
-        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-3">
-          <h5>Existing Stakers</h5>
-          <ul class="nav flex-column">
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/support">Support</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/mev-relay-list">MEV Relay List</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/smoothing-pools">Smoothing Pools</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/tax">Taxes</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/airdrops">Airdrops</a></li>
-            <!-- <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/jobs/job-listings">Jobs</a></li> -->
-          </ul>
-        </div>
-
-        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-3">
-          <h5>Updates</h5>
-          <ul class="nav flex-column">
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/incidents" target="_blank">Incidents</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/blog" target="_blank">Blog</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/rhino-review">Staking Newsletter</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/research" target="_blank">Current Research</a></li>
-          </ul>
-        </div>
-
-        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-3">
-          <h5>Community</h5>
-          <ul class="nav flex-column">
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="http://dsc.gg/ethstaker" target="_blank">Discord</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="https://reddit.com/r/ethstaker" target="_blank">Reddit</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="https://warpcast.com/~/channel/eth-staker" target="_blank">Farcaster</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="https://twitter.com/ethStaker" target="_blank">Twitter</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="https://www.youtube.com/@ETHStaker" target="_blank">YouTube</a></li>
-            <li class="nav-item mb-2"><a class="nav-link p-0 text-muted" href="/staking-communities">Allied Communities</a></li>
-          </ul>
-        </div>
-
-        <div class="col-12 my-3">
-          <div class="disclaimer mb-3 mt-3 mt-md-0">
-            <p><strong>Not financial or tax advice.</strong> EthStaker content is strictly educational and is not investment advice or a solicitation to buy or sell any assets or to make any financial decisions. This content is not tax advice. Talk to your accountant. Do your own research.</p>
-
-            <p><strong>Disclosure.</strong> We may link to projects or services we support and use. We do not receive commission if you use services through one of these links. Additionally, EthStaker stewards participate in projects and hold crypto assets. See our investments disclosures <a href="/disclosures">here</a>.</p>
-          </div>
-        </div>
-
+    <div class="footer-main">
+      <div class="footer-brand">
+        <a href="/" class="footer-logo" aria-label="EthStaker home">
+          <img src="/assets/img/ethstaker/logo-text-black.svg" alt="EthStaker" class="d-light">
+          <img src="/assets/img/ethstaker/logo-text-white.svg" alt="EthStaker" class="d-dark">
+        </a>
+        <p>Welcoming first, knowledgeable second.</p>
+        <p class="footer-parent">An initiative of <a href="https://ethcoordinate.org" target="_blank" rel="noopener noreferrer">EthCoordinate <span aria-hidden="true">↗</span></a></p>
+        <a href="mailto:team@ethstaker.org" class="footer-mail">team@ethstaker.org</a>
       </div>
 
-      <div class="d-flex flex-column flex-sm-row justify-content-md-between py-3 my-4 border-top">
-        <a href="/" class="text-center">
-          <img src="/assets/img/ethstaker/logo-text-black.svg" alt="Logo" height="35" class="d-inline-block d-light align-text-top my-2">
-          <img src="/assets/img/ethstaker/logo-text-white.svg" alt="Logo" height="35" class="d-inline-block d-dark align-text-top my-2">
-        </a>
-        <ul class="footer-socials list-unstyled d-flex justify-content-center">
-          <li class="me-3">
-            <a class="link-dark fs-3" href="http://dsc.gg/ethstaker" target="_blank">
-            {{site.data.icons.discord}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="https://www.youtube.com/@ETHStaker" target="_blank">
-            {{site.data.icons.youtube}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="https://reddit.com/r/ethstaker" target="_blank">
-            {{site.data.icons.reddit}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="https://twitter.com/ethStaker" target="_blank">
-            {{site.data.icons.twitter_x}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="https://www.linkedin.com/company/ethstaker/" target="_blank">
-            {{site.data.icons.linkedin}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="https://www.facebook.com/EthStakerOrg/" target="_blank">
-            {{site.data.icons.facebook}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="https://github.com/ethstaker/" target="_blank">
-            {{site.data.icons.github}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="{{site.calendar_link}}" target="_blank">
-            {{site.data.icons.calendar}}
-            </a>
-          </li>
-          <li class="me-3">
-            <a class="link-dark fs-3" href="mailto:team@ethstaker.org" target="_blank">
-            {{site.data.icons.mail2}}
-            </a>
-          </li>
-        </ul>
+      <div class="footer-nav-groups">
+        <nav aria-label="Intro links">
+          <span>Intro</span>
+          <a href="/about">About EthStaker</a>
+          <a href="/events">Events</a>
+          <a href="https://docs.ethstaker.org/faq" target="_blank">FAQ</a>
+          <a href="https://ethcoordinate.org" target="_blank">EthCoordinate</a>
+        </nav>
+        <nav aria-label="Get started links">
+          <span>Get Started</span>
+          <a href="/safety">Safety</a>
+          <a href="/staking">Staking</a>
+          <a href="https://docs.ethstaker.org/" target="_blank">Knowledge Base</a>
+          <a href="/solo-staking-guides">Guides</a>
+          <a href="/staking-hardware">Hardware</a>
+          <a href="/staking-software">Software</a>
+          <a href="/staking#staking-quiz">Staking Quiz</a>
+        </nav>
+        <nav aria-label="Existing stakers links">
+          <span>Existing Stakers</span>
+          <a href="/support">Support</a>
+          <a href="/mev-relay-list">MEV Relay List</a>
+          <a href="/smoothing-pools">Smoothing Pools</a>
+          <a href="/tax">Taxes</a>
+          <a href="/airdrops">Airdrops</a>
+          <!-- <a href="/jobs/job-listings">Jobs</a> -->
+        </nav>
+        <nav aria-label="Updates links">
+          <span>Updates</span>
+          <a href="/incidents" target="_blank">Incidents</a>
+          <a href="/blog" target="_blank">Blog</a>
+          <a href="/rhino-review">Staking Newsletter</a>
+          <a href="/research" target="_blank">Current Research</a>
+        </nav>
+        <nav aria-label="Community links">
+          <span>Community</span>
+          <a href="http://dsc.gg/ethstaker" target="_blank">Discord</a>
+          <a href="https://reddit.com/r/ethstaker" target="_blank">Reddit</a>
+          <a href="https://warpcast.com/~/channel/eth-staker" target="_blank">Farcaster</a>
+          <a href="https://twitter.com/ethStaker" target="_blank">Twitter</a>
+          <a href="https://www.youtube.com/@ETHStaker" target="_blank">YouTube</a>
+          <a href="/staking-communities">Allied Communities</a>
+        </nav>
+      </div>
+    </div>
+
+    <div class="footer-disclaimer">
+      <p><strong>Not financial or tax advice.</strong> EthStaker content is strictly educational and is not investment advice or a solicitation to buy or sell any assets or to make any financial decisions. This content is not tax advice. Talk to your accountant. Do your own research.</p>
+
+      <p><strong>Disclosure.</strong> We may link to projects or services we support and use. We do not receive commission if you use services through one of these links. Additionally, EthStaker stewards participate in projects and hold crypto assets. See our investments disclosures <a href="/disclosures">here</a>.</p>
+    </div>
+
+    <div class="footer-bottom">
+      <span>© {{ site.time | date: "%Y" }} EthStaker · An EthCoordinate initiative</span>
+      <div class="footer-links">
+        <a href="http://dsc.gg/ethstaker" target="_blank">Discord</a>
+        <a href="https://www.youtube.com/@ETHStaker" target="_blank">YouTube</a>
+        <a href="https://reddit.com/r/ethstaker" target="_blank">Reddit</a>
+        <a href="https://twitter.com/ethStaker" target="_blank">X</a>
+        <a href="https://www.linkedin.com/company/ethstaker/" target="_blank">LinkedIn</a>
+        <a href="https://www.facebook.com/EthStakerOrg/" target="_blank">Facebook</a>
+        <a href="https://github.com/ethstaker/" target="_blank">GitHub</a>
+        <a href="{{site.calendar_link}}" target="_blank">Calendar</a>
+        <a href="mailto:team@ethstaker.org">Email</a>
       </div>
     </div>
   </div>

--- a/_includes/partials/components/head.html
+++ b/_includes/partials/components/head.html
@@ -30,16 +30,17 @@
   <link rel="canonical" href="{{site.url}}" />
 
   {%- assign favicon = "/assets/img/ethstaker/icons" -%}
-  {%- assign color = "#E3FFFD" -%}
+  {%- assign color = "#000004" -%}
   <link rel="apple-touch-icon" sizes="180x180" href="{{favicon}}/apple-touch-icon.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="{{favicon}}/favicon-16x16.png" />
   <link rel="icon" type="image/png" sizes="32x32" href="{{favicon}}/favicon-32x32.png" />
   <link rel="manifest" href="{{favicon}}/site.webmanifest" />
-  <link rel="mask-icon" href="{{favicon}}/safari-pinned-tab.svg" color="{{color}}" />
+  <link rel="mask-icon" href="{{favicon}}/safari-pinned-tab.svg" color="#00D4FF" />
   <link rel="shortcut icon" href="{{favicon}}/favicon.ico" />
   <meta name="msapplication-TileColor" content="{{color}}" />
   <meta name="msapplication-config" content="{{favicon}}/browserconfig.xml" />
   <meta name="theme-color" content="{{color}}" />
+  <meta name="color-scheme" content="dark light" />
 
   {%- assign cover = site.url | append: "/assets/img/ethstaker/cover/cover.png" -%}
   <meta property="og:locale" content="en-US" />
@@ -57,6 +58,25 @@
   <meta name="twitter:image:src" content="{{cover}}" />
   <meta name="twitter:image:alt" content="{{title}}" />
 
+  <!-- Theme init: apply the saved theme (or the OS preference, dark by default)
+       before the first paint so there is no flash. Mirrors ethcoordinate.org. -->
+  <script>
+    (function () {
+      var root = document.documentElement;
+      var stored = null;
+      try { stored = localStorage.getItem("darkModeEnabled"); } catch (e) {}
+      var dark = (stored === "true" || stored === "false")
+        ? stored === "true"
+        : !window.matchMedia("(prefers-color-scheme: light)").matches;
+      root.setAttribute("data-bs-theme", dark ? "dark" : "light");
+      root.classList.toggle("dark-mode", dark);
+    })();
+  </script>
+  <style>
+    html { background-color: #000004; }
+    html[data-bs-theme="light"] { background-color: #F4F6F9; }
+  </style>
+
   <!-- Bootstrap 5 CSS -->
   {{site.bootstrap_css}}
   <!-- AOS CSS -->
@@ -64,9 +84,10 @@
   <!-- Bootstrap 5 JS -->
   {{site.bootstrap_js}}
 
-  <!-- Font -->
+  <!-- Font: JetBrains Mono, shared with ethcoordinate.org -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet" />
 
   <!-- Custom CSS -->
   <link rel="stylesheet" type="text/css" href="/assets/css/main.css" />

--- a/_includes/partials/components/nav.html
+++ b/_includes/partials/components/nav.html
@@ -1,38 +1,39 @@
 {%- if site.enable_nav == true -%}
-<style type="text/css">
-  .nav-link,
-  .nav-link:visited {
-    padding-bottom: 0px;
-  }
-</style>
-
-
-<nav class="navbar navbar-expand-lg">
+<nav class="navbar navbar-expand-lg site-nav" aria-label="Primary navigation">
   <div class="container">
-    <a class="navbar-brand" href="/">
-      <img src="/assets/img/ethstaker/logo-text-black.svg" alt="Logo" height="27" class="d-inline-block d-light align-text-top">
-      <img src="/assets/img/ethstaker/logo-text-white.svg" alt="Logo" height="27" class="d-inline-block d-dark align-text-top">
+    <a class="navbar-brand brand-link" href="/" aria-label="EthStaker home">
+      <img src="/assets/img/ethstaker/logo-text-black.svg" alt="EthStaker" class="brand-logo d-light">
+      <img src="/assets/img/ethstaker/logo-text-white.svg" alt="EthStaker" class="brand-logo d-dark">
+      <span class="brand-copy"><small>An EthCoordinate initiative</small></span>
     </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
+
+    <div class="nav-actions order-lg-last">
+      <a class="nav-cta d-none d-lg-inline-flex" href="/staking">Start staking</a>
+      {% include partials/components/dark-mode-toggle.html %}
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <svg class="icon-open" width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+        <svg class="icon-close" width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+      </button>
+    </div>
+
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav mb-3 mb-lg-0 flex-fill justify-content-center">
-        <li class="nav-item dropdown me-3">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navDropdownIntro" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Intro
           </a>
-          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <ul class="dropdown-menu" aria-labelledby="navDropdownIntro">
             <li><a class="dropdown-item" href="/about">About EthStaker</a></li>
             <li><a class="dropdown-item" href="/events">Events</a></li>
             <li><a class="dropdown-item" href="https://docs.ethstaker.org/faq" target="_blank">FAQ</a></li>
+            <li><a class="dropdown-item" href="https://ethcoordinate.org" target="_blank">EthCoordinate</a></li>
           </ul>
         </li>
-        <li class="nav-item dropdown me-3">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navDropdownStart" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Get Started
           </a>
-          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <ul class="dropdown-menu" aria-labelledby="navDropdownStart">
             <li><a class="dropdown-item" href="/staking">Staking</a></li>
             <li><a class="dropdown-item" href="https://docs.ethstaker.org/" target="_blank">Knowledge Base</a></li>
             <li><a class="dropdown-item" href="/solo-staking-guides">Guides</a></li>
@@ -41,11 +42,11 @@
             <li><a class="dropdown-item" href="/staking#staking-quiz">Staking Quiz</a></li>
           </ul>
         </li>
-        <li class="nav-item dropdown me-3">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navDropdownExisting" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Existing Stakers
           </a>
-          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <ul class="dropdown-menu" aria-labelledby="navDropdownExisting">
             <li><a class="dropdown-item" href="/support">Support</a></li>
             <li><a class="dropdown-item" href="/mev-relay-list">MEV Relay List</a></li>
             <li><a class="dropdown-item" href="/smoothing-pools">Smoothing Pools</a></li>
@@ -55,22 +56,22 @@
             <!-- <li><a class="dropdown-item" href="/jobs/job-listings">Jobs</a></li> -->
           </ul>
         </li>
-        <li class="nav-item dropdown me-3">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navDropdownUpdates" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Updates
           </a>
-          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <ul class="dropdown-menu" aria-labelledby="navDropdownUpdates">
             <li><a class="dropdown-item" href="/incidents" target="_blank">Incidents</a></li>
             <li><a class="dropdown-item" href="/blog" target="_blank">Blog</a></li>
             <li><a class="dropdown-item" href="/rhino-review">Staking Newsletter</a></li>
             <li><a class="dropdown-item" href="/research" target="_blank">Current Research</a></li>
           </ul>
         </li>
-        <li class="nav-item dropdown me-3">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navDropdownCommunity" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Community
           </a>
-          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <ul class="dropdown-menu" aria-labelledby="navDropdownCommunity">
             <li><a class="dropdown-item" href="http://dsc.gg/ethstaker" target="_blank">Discord</a></li>
             <li><a class="dropdown-item" href="https://reddit.com/r/ethstaker" target="_blank">Reddit</a></li>
             <li><a class="dropdown-item" href="https://warpcast.com/~/channel/eth-staker" target="_blank">Farcaster</a></li>
@@ -79,15 +80,8 @@
             <li><a class="dropdown-item" href="/staking-communities">Allied Communities</a></li>
           </ul>
         </li>
-        <li class="nav-item me-5">
-          <!-- keep this, used to center the header -->
-        </li>
       </ul>
-      <form class="d-flex mb-auto" role="search">
-        <!-- <a class="btn btn-warning shadow-sm me-2" href=""></a> -->
-        <a class="btn btn-outline-dark shadow-sm" href="/staking">Start Staking</a>
-        {% include partials/components/dark-mode-toggle.html %}
-      </form>
+      <a class="nav-cta nav-cta--mobile d-lg-none" href="/staking">Start staking →</a>
     </div>
   </div>
 </nav>

--- a/_includes/partials/components/notification.html
+++ b/_includes/partials/components/notification.html
@@ -1,8 +1,8 @@
 {%- comment -%}
-<!-- 
-When creating new notification you must increase 
-the config.yml "notification_msg_id" value so it 
-will show again for users that previously closed it 
+<!--
+When creating new notification you must increase
+the config.yml "notification_msg_id" value so it
+will show again for users that previously closed it
 
 Add to config.yml:
 # Notification Bar
@@ -10,38 +10,18 @@ enable_notification: false
 notification_msg_id: 1 # must increment when creating a new message
 notification_msg: Join the community!<br><a href=""></a>.
 notification_expiration: 3000000000 # epoch time in seconds
+
+Styles live in assets/css/main.css (#notification).
 -->
 {%- endcomment -%}
 
 {%- if site.enable_notification == true -%}
-<style type="text/css">
-  #notification {
-    position: fixed;
-    z-index: 101;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    color: var(--bs-dark);
-    text-align: center;
-    overflow: hidden;
-    box-shadow: 0 -0.5rem 1rem rgba(0,0,0,.15);
-    background-color: var(--bs-body-bg);
-  }
-  #notification a {
-    color: var(--bs-dark);
-  }
-  #notificationClose {
-    cursor: pointer;
-  }
-</style>
-
-
 <!-- Notification Bar -->
-<div id="notification" class="d-none d-flex bg-warning">
+<div id="notification" class="d-none d-flex">
   <span id="notification_msg" class="flex-grow-1 py-2 ps-3 pe-1">
     {{site.notification_msg}}
   </span>
-  <span id="notificationClose" class="mx-2 my-auto py-1 px-2" onclick="hideNotification()">✕</span>
+  <span id="notificationClose" class="mx-2 my-auto py-1 px-2" onclick="hideNotification()" role="button" aria-label="Dismiss notification">✕</span>
 </div>
 
 

--- a/_includes/partials/components/toast.html
+++ b/_includes/partials/components/toast.html
@@ -23,7 +23,7 @@ toast_expiration: 3000000000 # epoch time in seconds
   }
   .toast {
     border-radius: 0.5rem !important;
-    background-color: var(--bs-body-bg);
+    background-color: var(--color-bg-elevated);
   }
   .toast-header {
     

--- a/_includes/partials/content/index/blog.html
+++ b/_includes/partials/content/index/blog.html
@@ -20,7 +20,8 @@
   <div class="container my-3 my-md-0 my-lg-4 p-4 py-md-5">
     <div class="row justify-content-center">
       <div class="col-12 col-lg-9 col-xl-8 col-xxl-7 p-md-3 pt-lg-3 text-center aos-up">
-        <h2 class="display-4 fw-bold lh-1 mb-3">Latest Posts</h2>
+        <p class="eyebrow">From the community</p>
+        <h2 class="section-title">Latest posts</h2>
       </div>
     </div>
     <div class="row justify-content-center my-5">

--- a/_includes/partials/content/index/events.html
+++ b/_includes/partials/content/index/events.html
@@ -3,7 +3,8 @@
   <div class="container my-3 my-md-0 my-lg-4 p-4 py-md-5">
     <div class="row justify-content-center">
       <div class="col-12 col-lg-9 col-xl-8 col-xxl-7 p-md-3 pt-lg-3 text-center aos-up">
-        <h2 class="display-4 fw-bold lh-1 mb-3">Educational Events</h2>
+        <p class="eyebrow">Learn together</p>
+        <h2 class="section-title">Educational events</h2>
       </div>
     </div>
     <div class="row justify-content-center align-items-center">

--- a/_includes/partials/content/index/header.html
+++ b/_includes/partials/content/index/header.html
@@ -1,51 +1,27 @@
-<style type="text/css">
-  header .quote {
-    background: linear-gradient(to right, rgba(var(--brand-color-1-rgb),1) 85%,rgba(var(--brand-color-1-rgb),0) 100%);
-    border-left: 2px solid var(--brand-color-4);
-  }
-  header .floating-hover {
-    margin-top: -3em;
-  }
-</style>
+<!-- Hero — mirrors the ethcoordinate.org hero: eyebrow, name, lead, terminal -->
+<header class="es-hero">
+  <img class="hero-bg-mark" src="/assets/img/ethstaker/logo-blue.svg" alt="" aria-hidden="true">
+  <div class="hero-glow" aria-hidden="true"></div>
 
+  <div class="container hero-inner">
+    <p class="hero-eyebrow">An EthCoordinate initiative</p>
+    <h1 class="hero-title"><strong>EthStaker</strong></h1>
+    <p class="hero-lead">EthStaker is a community providing guidance, education, support, and resources for existing and potential stakers. Our principal goal is to maximize decentralization of the Ethereum network.</p>
 
-<!-- Header -->
-<header class="mt-0 mt-sm-2 mt-md-3 mt-xl-5 pt-4 pt-md-5">
-  <div class="container my-0 mt-lg-4 mb-lg-2 p-4">
-    <div class="row justify-content-center align-items-center">
-      <div class="col-12 col-xl-7 p-md-3 p-lg-5 pt-lg-3 aos-right">
-        <h1 class="display-4 fw-bold lh-1 mb-3">What is EthStaker?</h1>
-        <p class="lead quote text-dark fw-semibold py-2 px-3 ps-lg-4"><em>"Welcoming first, knowledgeable second"</em></p>
-        <p class="lead">EthStaker is a community providing guidance, education, support, and resources for existing and potential stakers. EthStaker’s principal goal is to maximize decentralization of the Ethereum network.</p>
-        <div class="gap-2 d-md-flex justify-content-md-start mb-4 mb-lg-3">
-          <a href="/about" class="btn btn-dark btn-lg shadow">Learn more</a>
-        </div>
+    <div class="terminal" aria-label="EthStaker status">
+      <div class="terminal-bar">
+        <span class="terminal-dot r"></span>
+        <span class="terminal-dot y"></span>
+        <span class="terminal-dot g"></span>
+        <span class="terminal-title">ethstaker — status</span>
       </div>
-      <div class="col-lg-4 ps-xxl-5 d-none d-xl-block aos-left">
-        <img class="floating-hover" src="/assets/img/ethstaker/logo-blue.svg" alt="">
+      <div class="terminal-body">
+        <div class="t-line"><span class="t-prompt">→</span><span class="t-cmd">./ethstaker --status</span></div>
+        <div class="t-out">✓ <a href="https://docs.ethstaker.org/" target="_blank">Knowledge base</a>, guides, and support channels are open</div>
+        <div class="t-out">✓ Solo staking remains the gold standard</div>
+        <div class="t-out">✓ Staker support · An initiative of <a href="https://ethcoordinate.org" target="_blank">EthCoordinate</a></div>
+        <div class="t-line"><span class="t-prompt">→</span><span class="cursor"></span></div>
       </div>
     </div>
   </div>
 </header>
-
-
-{%- comment -%}
-<!-- Header reversed -->
-<header class="d-none mt-0 mt-sm-2 mt-md-3 mt-xl-5 pt-4 pt-md-5">
-  <div class="container my-0 mt-lg-4 mb-lg-2 p-4">
-    <div class="row justify-content-center align-items-center">
-      <div class="col-lg-4 pe-xxl-5 d-none d-xl-block aos-right">
-        <img class="floating-hover" src="/assets/img/ethstaker/logo-blue.svg" alt="">
-      </div>
-      <div class="col-12 col-xl-7 p-md-3 p-lg-5 pt-lg-3">
-        <h1 class="display-4 fw-bold lh-1 mb-3">What is EthStaker?</h1>
-        <p class="lead fw-semibold quote py-2 px-3 ps-lg-4 aos-left"><em>"Welcoming first, knowledgeable second"</em></p>
-        <p class="lead">EthStaker is a community providing guidance, education, support, and resources for existing and potential stakers. EthStaker’s principal goal is to maximize decentralization of the Ethereum network.</p>
-        <div class="gap-2 d-md-flex justify-content-md-start mb-4 mb-lg-3">
-          <a href="/about" class="btn btn-dark btn-lg shadow">Learn more</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</header>
-{%- endcomment -%}

--- a/_includes/partials/content/index/resources.html
+++ b/_includes/partials/content/index/resources.html
@@ -1,9 +1,10 @@
 <style type="text/css">
   #staking-resources .resouce-icon svg {
-    height: 2.5rem;
-    width: 2.5rem;
-    max-width: 2.5rem;
-    max-height: 2.5rem;
+    height: 2.25rem;
+    width: 2.25rem;
+    max-width: 2.25rem;
+    max-height: 2.25rem;
+    color: var(--color-blue);
   }
   #staking-resources .icon {
     display: none;
@@ -13,6 +14,9 @@
     color: var(--bs-body-color);
     word-wrap: normal;
   }
+  #staking-resources .card-title {
+    font-size: 0.9rem;
+  }
 </style>
 
 
@@ -21,7 +25,9 @@
   <div class="container my-3 my-md-0 my-lg-4 p-4 py-md-5">
     <div class="row justify-content-center">
       <div class="col-12 col-lg-9 col-xl-8 col-xxl-7 p-md-3 pt-lg-3 text-center aos-up">
-        <h2 class="display-4 fw-bold lh-1 mb-3">Resources</h2>
+        <p class="eyebrow">Staking resources</p>
+        <h2 class="section-title">Resources</h2>
+        <p class="lead">Documentation, guides, and tooling for every stage of running a validator.</p>
       </div>
     </div>
     <div class="row justify-content-center mt-2">

--- a/_includes/partials/content/index/staking-gathering-2025-post.html
+++ b/_includes/partials/content/index/staking-gathering-2025-post.html
@@ -10,7 +10,8 @@
   <div class="container my-3 my-md-0 my-lg-4 p-4 py-md-5">
     <div class="row justify-content-center">
       <div class="col-12 col-lg-9 col-xl-8 col-xxl-7 p-md-3 pt-lg-3 text-center aos-up">
-        <h2 class="display-4 fw-bold lh-1 mb-3">Staking Gathering Recordings</h2>
+        <p class="eyebrow">Event recordings</p>
+        <h2 class="section-title">Staking Gathering recordings</h2>
       </div>
     </div>
     <div class="row justify-content-center align-items-center">

--- a/_includes/partials/content/index/staking.html
+++ b/_includes/partials/content/index/staking.html
@@ -2,6 +2,33 @@
   #staking .floating-hover {
     margin-top: -2em;
   }
+  #staking .benefit svg {
+    color: var(--color-blue);
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-top: 0.15rem;
+  }
+  #staking .benefit p {
+    font-size: 0.9rem;
+  }
+  /* All cycled words share one grid cell, so the highlight keeps the width of the
+     longest word and the text around it never reflows. */
+  #staking .word-cycle {
+    display: inline-grid;
+    text-align: center;
+  }
+  #staking .word-cycle-item {
+    grid-area: 1 / 1;
+    visibility: hidden;
+  }
+  #staking .word-cycle-item.is-active {
+    visibility: visible;
+  }
+  /* Slightly below Bootstrap's h3 default so the sentence stays on one line at desktop widths */
+  #staking h3 { font-size: 1.6rem; }
+  @media (max-width: 575.98px) {
+    #staking h3 { font-size: 1.4rem; }
+  }
 </style>
 
 
@@ -10,7 +37,8 @@
   <div class="container my-3 my-md-0 my-lg-4 p-4 py-md-5">
     <div class="row justify-content-center">
       <div class="col-12 col-lg-9 col-xl-8 col-xxl-7 p-md-3 pt-lg-3 text-center aos-up">
-        <h2 class="display-4 fw-bold lh-1 mb-3">Staking Is for Everyone</h2>
+        <p class="eyebrow">Start staking</p>
+        <h2 class="section-title">Staking is for everyone.</h2>
       </div>
     </div>
     <div class="row justify-content-center align-items-center">
@@ -19,27 +47,35 @@
       </div>
       <div class="col-12 col-xl-7 p-md-3 p-lg-5 pt-lg-3 aos-left">
         <h3 class="mb-3">
-          A <span id="wordCycle" class="bg-brand-color-1 text-dark fw-semibold fst-italic px-2 py-1">better</span> Ethereum starts with you
+          A <span id="wordCycle" class="word-cycle bg-brand-color-1 text-dark fw-semibold fst-italic px-2 py-1">
+            <span class="word-cycle-item is-active">better</span>
+            <span class="word-cycle-item">stronger</span>
+            <span class="word-cycle-item">healthier</span>
+            <span class="word-cycle-item">secure</span>
+            <span class="word-cycle-item">decentralized</span>
+            <span class="word-cycle-item">robust</span>
+            <span class="word-cycle-item">valuable</span>
+          </span> Ethereum starts with you
         </h3>
         <p class="lead">Solo staking is a great way to not only improve Ethereum, but also to generate low-risk rewards using your ETH. While solo staking is the gold standard, there's a variety of other options that each have their own requirements, risks, and considerations.</p>
-        <div class="row mt-4 fw-light fs-5">
+        <div class="row mt-4">
           <div class="col-12 col-lg-6">
-            <div class="d-flex">
-              <div class="me-4">{{site.data.icons.graph_up}}</div>
+            <div class="d-flex benefit">
+              <div class="me-3">{{site.data.icons.graph_up}}</div>
               <p class="">Earn ETH protocol rewards</p>
             </div>
-            <div class="d-flex">
-              <div class="me-4">{{site.data.icons.shield}}</div>
+            <div class="d-flex benefit">
+              <div class="me-3">{{site.data.icons.shield}}</div>
               <p class=" mb-lg-0">Secure the network</p>
             </div>
           </div>
           <div class="col-12 col-lg-6 mb-6 mb-md-0">
-            <div class="d-flex">
-              <div class="me-4">{{site.data.icons.globe}}</div>
+            <div class="d-flex benefit">
+              <div class="me-3">{{site.data.icons.globe}}</div>
               <p class="">Boost decentralization</p>
             </div>
-            <div class="d-flex">
-              <div class="me-4">{{site.data.icons.person_lock}}</div>
+            <div class="d-flex benefit">
+              <div class="me-3">{{site.data.icons.person_lock}}</div>
               <p class=" mb-0">Non-custodial</p>
             </div>
           </div>
@@ -56,33 +92,13 @@
 </section>
 
 
-{%- comment -%}
-<!-- Start Staking -->
-<section class="d-none gradient-bg3">
-  <div class="container my-3 my-md-0 my-lg-4 p-4 py-md-5">
-    <div class="row justify-content-center align-items-center">
-      <div class="col-12 col-lg-9 col-xl-8 col-xxl-7 p-md-3 p-lg-3 text-center aos-up">
-        <h2 class="display-4 fw-bold lh-1 mb-3">Start Staking</h2>
-        <p class="lead">EthStaker is a community providing guidance, education, support, and resources for existing and potential stakers to interact. EthStaker’s principal goal is to maximize decentralization of the Ethereum network.</p>
-        <div class="gap-2">
-          <a href="/staking" class="btn btn-dark btn-lg mt-4 shadow">Get started</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-{%- endcomment -%}
-
-
 <script type="text/javascript">
+  // Cycles the highlighted word by toggling visibility; the words themselves live in the markup
+  var wordItems = document.querySelectorAll("#wordCycle .word-cycle-item");
   var wordIndex = 0;
-  var wordList = ["better","stronger","healthier","secure","decentralized","robust","valuable"]
-  const interval = setInterval(function() {
-    var word = document.getElementById("wordCycle");
-    wordIndex += 1;
-    if (wordIndex >= wordList.length) {
-      wordIndex = 0;
-    }
-    word.innerHTML = wordList[wordIndex];
+  setInterval(function() {
+    wordItems[wordIndex].classList.remove("is-active");
+    wordIndex = (wordIndex + 1) % wordItems.length;
+    wordItems[wordIndex].classList.add("is-active");
   }, 1000);
 </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" class="h-100" data-bs-theme="light">
+<html lang="en" class="h-100 dark-mode" data-bs-theme="dark">
   {%- include partials/components/head.html -%}
   <body class="d-flex flex-column min-vh-100">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <div class="scanlines" aria-hidden="true"></div>
 
     {%- include partials/components/notification.html -%}
     {%- include partials/components/toast.html -%}
@@ -9,7 +11,9 @@
     {%- include partials/components/nav.html -%}
 
 
+    <main id="main-content">
     {{content}}
+    </main>
 
 
     {%- include partials/components/footer.html -%}

--- a/_layouts/markdown.html
+++ b/_layouts/markdown.html
@@ -1,46 +1,67 @@
 <!DOCTYPE html>
-<html lang="en" class="h-100" data-bs-theme="light">
+<html lang="en" class="h-100 dark-mode" data-bs-theme="dark">
   {%- include partials/components/head.html -%}
   <body class="d-flex flex-column min-vh-100">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <div class="scanlines" aria-hidden="true"></div>
 
     {%- include partials/components/notification.html -%}
     {%- include partials/components/toast.html -%}
     {%- include partials/components/contribute.html -%}
     {%- include partials/components/nav.html -%}
 
+    {%- assign width = "col col-md-8 col-lg-7" -%}
+    {%- if page.width -%}
+      {%- assign width = page.width -%}
+    {%- endif -%}
+
+    <main id="main-content">
 
     <!-- Header -->
-    <header class="markdown-header">
-      <div class="container pt-3 pb-5 my-2 text-center">
-        {%- assign header = page.title -%}
-        {%- if page.header -%}
-          {%- assign header = page.header -%}
-        {%- endif -%}
-        {%- if header != "" -%}
-          <h1 class="display-5 fw-bold text-capitalize mt-5">{{header}}</h1>
-        {%- endif -%}
-
-        {%- if page.subheader -%}
-          <div class="col-md-10 col-lg-6 mx-auto lead mb-3">
-            {{page.subheader | flatify | markdownify}}
-          </div>
-        {%- endif -%}
-
-        {%- if page.note -%}
-          <div class="mb-3">
-            <small><em>{{page.note}}</em></small>
-          </div>
-        {%- endif -%}
-
-        {%- if page.buttons -%}
-          {%- for button in page.buttons -%}
-            {%- assign design = "btn-outline-dark" -%}
-            {%- if button.primary == true -%}
-              {%- assign design = "btn-dark" -%}
+    <header class="markdown-header page-header">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="{{width}}">
+            {%- assign header = page.title -%}
+            {%- if page.header -%}
+              {%- assign header = page.header -%}
             {%- endif -%}
-            <a href="{{button.link | liquify}}" class="btn {{design}} px-4 mx-2 my-1 shadow">{{button.text | liquify}}</a>
-          {%- endfor -%}
-        {%- endif -%}
+
+            {%- assign eyebrow = "EthStaker" -%}
+            {%- if page.eyebrow -%}
+              {%- assign eyebrow = page.eyebrow -%}
+            {%- endif -%}
+            <p class="page-eyebrow">{{eyebrow}}</p>
+
+            {%- if header != "" -%}
+              <h1 class="page-title">{{header}}</h1>
+            {%- endif -%}
+
+            {%- if page.subheader -%}
+              <div class="page-desc">
+                {{page.subheader | flatify | markdownify}}
+              </div>
+            {%- endif -%}
+
+            {%- if page.note -%}
+              <p class="page-note"><em>{{page.note}}</em></p>
+            {%- endif -%}
+
+            {%- if page.buttons -%}
+              <div class="page-actions">
+                {%- for button in page.buttons -%}
+                  {%- assign design = "btn-outline-dark" -%}
+                  {%- if button.primary == true -%}
+                    {%- assign design = "btn-dark" -%}
+                  {%- endif -%}
+                  <a href="{{button.link | liquify}}" class="btn {{design}}">{{button.text | liquify}}</a>
+                {%- endfor -%}
+              </div>
+            {%- endif -%}
+
+            <div class="page-divider" aria-hidden="true"></div>
+          </div>
+        </div>
       </div>
     </header>
 
@@ -50,10 +71,6 @@
       <section class="markdown">
         <div class="container">
           <div class="row justify-content-center">
-            {%- assign width = "col col-md-8 col-lg-7" -%}
-            {%- if page.width -%}
-              {%- assign width = page.width -%}
-            {%- endif -%}
             <div class="{{width}} markdown-aos">
               {{content | markdownify}}
             </div>
@@ -61,6 +78,8 @@
         </div>
       </section>
     {%- endif -%}
+
+    </main>
 
 
     {%- include partials/components/footer.html -%}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,257 +1,1090 @@
-:root {
-  /* light blue */
-  --brand-color-1: #E3FFFD; 
-  --brand-color-1-rgb: 227, 255, 253;
-  /* bright blue */
-  --brand-color-2: #00FFFF;
-  --brand-color-2-rgb: 0, 255, 255;
-  /* dark blue */
-  --brand-color-3: #0071BC;
-  --brand-color-3-rgb: 0, 113, 188;
-  /* off-black */
-  --brand-color-4: #333333;
-  --brand-color-4-rgb: 51, 51, 51;
+/* =============================================================
+   ETHSTAKER — EthCoordinate design system
+   Tokens, type, and components mirror ethcoordinate.org so both
+   sites read as one family. Bootstrap 5.3 keeps doing layout; its
+   CSS variables are remapped onto the shared tokens below.
+   ============================================================= */
 
+/* -------------------------------------------------------------
+   TOKENS — dark (default)
+   ------------------------------------------------------------- */
+:root,
+[data-bs-theme="dark"] {
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --color-blue: #00D4FF;
+  --color-blue-light: #5CE1FF;
+  --color-blue-muted: #0088AA;
+  --color-blue-dim: #004466;
+  --color-purple: #A855F7;
+  --color-purple-light: #C084FC;
+  --color-purple-muted: #7C3AED;
+
+  --color-bg-void: #000004;
+  --color-bg-deep: #04040A;
+  --color-bg-surface: #0A0A12;
+  --color-bg-elevated: #12121A;
+
+  --color-text-bright: #F0F6FF;
+  --color-text-body: #A9B1BD;
+  --color-text-secondary: #7DD3FC;
+  --color-text-muted: #8A8A8A;
+  --color-text-dim: #1E3A5F;
+
+  --color-border: #1E3A5F;
+  --color-border-hover: #0088AA;
+
+  --coord-cyan: #00D4FF;
+  --coord-yellow: #FBBF24;
+  --coord-purple: #A78BFA;
+  --coord-green: #34D399;
+  --coord-pink: #F472B6;
+  --coord-orange: #FB923C;
+
+  --tint-blue: rgba(0, 212, 255, 0.06);
+  --tint-blue-strong: rgba(0, 212, 255, 0.14);
+  --tint-purple: rgba(168, 85, 247, 0.10);
+  --tint-green: rgba(52, 211, 153, 0.08);
+  --glow-blue: rgba(0, 212, 255, 0.08);
+  --shadow-float: 0 18px 45px rgba(0, 0, 0, 0.28);
+  --nav-backdrop: rgba(3, 3, 8, 0.8);
+
+  /* Legacy EthStaker brand variables, remapped so existing partials keep working */
+  --brand-color-1: #E0F2FE;
+  --brand-color-1-rgb: 224, 242, 254;
+  --brand-color-2: var(--color-blue);
+  --brand-color-2-rgb: 0, 212, 255;
+  --brand-color-3: var(--color-purple);
+  --brand-color-3-rgb: 168, 85, 247;
+  --brand-color-4: var(--color-text-bright);
+  --brand-color-4-rgb: 240, 246, 255;
   --brand-shadow-1: 0 0 0 0.25rem;
+  --gold-1-rgb: 251, 191, 36;
+  --gold-2-rgb: 255, 247, 214;
+  --gold-3-rgb: 253, 230, 138;
+  --gold-4: #FBBF24;
 
-  --gold-1-rgb: 226,215,107;
-  --gold-2-rgb: 255,252,224;
-  --gold-3-rgb: 239,233,176;
-  --gold-4: #c2b439;
-}
+  /* Bootstrap remaps */
+  --bs-font-sans-serif: var(--font-mono);
+  --bs-font-monospace: var(--font-mono);
+  --bs-body-font-family: var(--font-mono);
+  --bs-body-font-size: 0.95rem;
+  --bs-body-line-height: 1.7;
+  --bs-body-bg: var(--color-bg-void);
+  --bs-body-bg-rgb: 0, 0, 4;
+  --bs-body-color: var(--color-text-body);
+  --bs-body-color-rgb: 169, 177, 189;
+  --bs-emphasis-color: var(--color-text-bright);
+  --bs-emphasis-color-rgb: 240, 246, 255;
+  --bs-secondary-color: var(--color-text-muted);
+  --bs-secondary-color-rgb: 138, 138, 138;
+  --bs-secondary-bg: var(--color-bg-surface);
+  --bs-secondary-bg-rgb: 10, 10, 18;
+  --bs-tertiary-color: var(--color-text-muted);
+  --bs-tertiary-color-rgb: 138, 138, 138;
+  --bs-tertiary-bg: var(--color-bg-elevated);
+  --bs-tertiary-bg-rgb: 18, 18, 26;
+  --bs-heading-color: var(--color-text-bright);
+  --bs-link-color: var(--color-blue);
+  --bs-link-color-rgb: 0, 212, 255;
+  --bs-link-hover-color: var(--color-blue-light);
+  --bs-link-hover-color-rgb: 92, 225, 255;
+  --bs-code-color: var(--color-purple-light);
+  --bs-highlight-bg: rgba(251, 191, 36, 0.25);
+  --bs-border-color: var(--color-border);
+  --bs-border-color-translucent: rgba(30, 58, 95, 0.6);
+  --bs-border-radius: 6px;
+  --bs-border-radius-sm: 4px;
+  --bs-border-radius-lg: 8px;
+  --bs-border-radius-xl: 10px;
+  --bs-box-shadow: none;
+  --bs-box-shadow-sm: none;
+  --bs-box-shadow-lg: none;
+  --bs-focus-ring-color: rgba(0, 212, 255, 0.25);
 
-
-.bg-tertiary {
-  background-color: var(--bs-tertiary-bg);
-}
-
-
-.brand-color-1 {
-  color: var(--brand-color-1);
-}
-.bg-brand-color-1 {
-  background-color: var(--brand-color-1);
-}
-.brand-color-2 {
-  color: var(--brand-color-2);
-}
-.bg-brand-color-2 {
-  background-color: var(--brand-color-2);
-}
-.brand-color-3 {
-  color: var(--brand-color-3);
-}
-.bg-brand-color-3 {
-  background-color: var(--brand-color-3);
-}
-.brand-color-4 {
-  color: var(--brand-color-4);
-}
-.bg-brand-color-4 {
-  background-color: var(--brand-color-4);
-}
-.brand-gradient-1 {
-  background: linear-gradient(45deg, rgba(var(--brand-color-2-rgb),1) 0%, rgba(var(--brand-color-3-rgb),1) 100%);
-}
-.brand-gradient-2 {
-  background: linear-gradient(to top, rgba(var(--bs-light-rgb),1) 70%,rgba(var(--bs-light-rgb),0) 100%) !important;
-}
-.brand-gradient-3 {
-  background: linear-gradient(to top, rgba(var(--brand-color-1-rgb),0) 0%,
-                                      rgba(var(--brand-color-1-rgb),1) 30%,
-                                      rgba(var(--brand-color-1-rgb),1) 70%,
-                                      rgba(var(--brand-color-1-rgb),0) 100%) !important;
-}
-.brand-gradient-4 {
-  background: linear-gradient(to top, rgba(var(--brand-color-1-rgb),0) 0%,
-                                      rgba(var(--brand-color-1-rgb),1) 10%,
-                                      rgba(var(--brand-color-1-rgb),1) 90%,
-                                      rgba(var(--brand-color-1-rgb),0) 100%) !important;
-}
-.brand-gradient-5 {
-  background: linear-gradient(to top, rgba(var(--brand-color-1-rgb),0) 0%,
-                                      rgba(var(--brand-color-1-rgb),1) 40%,
-                                      rgba(var(--brand-color-1-rgb),1) 60%,
-                                      rgba(var(--brand-color-1-rgb),0) 100%) !important;
-}
-
-.btn-devconnect {
-  --bs-btn-color: #000;
-  --bs-btn-bg: #05d39b;
-  --bs-btn-border-color: #05d39b;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #05e0a4;
-  --bs-btn-hover-border-color: #05e0a4;
-  --bs-btn-focus-shadow-rgb: 217, 164, 6;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #05e0a4;
-  --bs-btn-active-border-color: #05e0a4;
-  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
-  --bs-btn-disabled-bg: #05d39b;
-  --bs-btn-disabled-border-color: #05d39b;
+  --bs-primary: #00D4FF;
+  --bs-primary-rgb: 0, 212, 255;
+  --bs-primary-text-emphasis: #7DD3FC;
+  --bs-primary-bg-subtle: rgba(0, 212, 255, 0.08);
+  --bs-primary-border-subtle: rgba(0, 212, 255, 0.35);
+  --bs-info: #00D4FF;
+  --bs-info-rgb: 0, 212, 255;
+  --bs-info-text-emphasis: #7DD3FC;
+  --bs-info-bg-subtle: rgba(0, 212, 255, 0.08);
+  --bs-info-border-subtle: rgba(0, 212, 255, 0.35);
+  --bs-success: #34D399;
+  --bs-success-rgb: 52, 211, 153;
+  --bs-success-text-emphasis: #6EE7B7;
+  --bs-success-bg-subtle: rgba(52, 211, 153, 0.08);
+  --bs-success-border-subtle: rgba(52, 211, 153, 0.35);
+  --bs-warning: #FBBF24;
+  --bs-warning-rgb: 251, 191, 36;
+  --bs-warning-text-emphasis: #FCD34D;
+  --bs-warning-bg-subtle: rgba(251, 191, 36, 0.08);
+  --bs-warning-border-subtle: rgba(251, 191, 36, 0.35);
+  --bs-danger: #F87171;
+  --bs-danger-rgb: 248, 113, 113;
+  --bs-danger-text-emphasis: #FCA5A5;
+  --bs-danger-bg-subtle: rgba(248, 113, 113, 0.08);
+  --bs-danger-border-subtle: rgba(248, 113, 113, 0.35);
+  --bs-secondary: #8A8A8A;
+  --bs-secondary-rgb: 138, 138, 138;
+  --bs-light: #F0F6FF;
+  --bs-light-rgb: 240, 246, 255;
+  --bs-dark: #0A0A12;
+  --bs-dark-rgb: 10, 10, 18;
 }
 
+/* -------------------------------------------------------------
+   TOKENS — light
+   ------------------------------------------------------------- */
+[data-bs-theme="light"] {
+  --color-blue: #0891B2;
+  --color-blue-light: #06B6D4;
+  --color-blue-muted: #0E7490;
+  --color-blue-dim: #E0F2FE;
+  --color-purple: #7C3AED;
+  --color-purple-light: #8B5CF6;
+  --color-purple-muted: #6D28D9;
 
+  --color-bg-void: #F4F6F9;
+  --color-bg-deep: #E2E5EB;
+  --color-bg-surface: #FFFFFF;
+  --color-bg-elevated: #EDF0F4;
 
+  --color-text-bright: #0F172A;
+  --color-text-body: #334155;
+  --color-text-secondary: #0E7490;
+  --color-text-muted: #64748B;
+  --color-text-dim: #94A3B8;
+
+  --color-border: #C1C9D4;
+  --color-border-hover: #0891B2;
+
+  --coord-cyan: #0C6478;
+  --coord-yellow: #92400E;
+  --coord-purple: #6D28D9;
+  --coord-green: #047857;
+  --coord-pink: #BE185D;
+  --coord-orange: #C2410C;
+
+  --tint-blue: rgba(8, 145, 178, 0.08);
+  --tint-blue-strong: rgba(8, 145, 178, 0.16);
+  --tint-purple: rgba(109, 40, 217, 0.12);
+  --tint-green: rgba(4, 120, 87, 0.08);
+  --glow-blue: rgba(8, 145, 178, 0.14);
+  --shadow-float: 0 18px 45px rgba(15, 23, 42, 0.14);
+  --nav-backdrop: rgba(244, 246, 249, 0.9);
+
+  --brand-color-1: #E0F2FE;
+  --brand-color-1-rgb: 224, 242, 254;
+  --brand-color-2-rgb: 8, 145, 178;
+  --brand-color-3-rgb: 124, 58, 237;
+  --brand-color-4-rgb: 15, 23, 42;
+  --gold-1-rgb: 251, 191, 36;
+  --gold-2-rgb: 255, 251, 235;
+  --gold-3-rgb: 253, 230, 138;
+  --gold-4: #B45309;
+
+  --bs-body-bg: var(--color-bg-void);
+  --bs-body-bg-rgb: 244, 246, 249;
+  --bs-body-color: var(--color-text-body);
+  --bs-body-color-rgb: 51, 65, 85;
+  --bs-emphasis-color: var(--color-text-bright);
+  --bs-emphasis-color-rgb: 15, 23, 42;
+  --bs-secondary-color: var(--color-text-muted);
+  --bs-secondary-color-rgb: 100, 116, 139;
+  --bs-secondary-bg: var(--color-bg-surface);
+  --bs-secondary-bg-rgb: 255, 255, 255;
+  --bs-tertiary-color: var(--color-text-muted);
+  --bs-tertiary-color-rgb: 100, 116, 139;
+  --bs-tertiary-bg: var(--color-bg-elevated);
+  --bs-tertiary-bg-rgb: 237, 240, 244;
+  --bs-heading-color: var(--color-text-bright);
+  --bs-link-color: var(--color-blue);
+  --bs-link-color-rgb: 8, 145, 178;
+  --bs-link-hover-color: var(--color-blue-muted);
+  --bs-link-hover-color-rgb: 14, 116, 144;
+  --bs-code-color: var(--color-purple-muted);
+  --bs-border-color: var(--color-border);
+  --bs-border-color-translucent: rgba(193, 201, 212, 0.7);
+  --bs-focus-ring-color: rgba(8, 145, 178, 0.25);
+
+  --bs-primary: #0891B2;
+  --bs-primary-rgb: 8, 145, 178;
+  --bs-primary-text-emphasis: #0E7490;
+  --bs-primary-bg-subtle: rgba(8, 145, 178, 0.10);
+  --bs-primary-border-subtle: rgba(8, 145, 178, 0.35);
+  --bs-info: #0891B2;
+  --bs-info-rgb: 8, 145, 178;
+  --bs-info-text-emphasis: #0E7490;
+  --bs-info-bg-subtle: rgba(8, 145, 178, 0.10);
+  --bs-info-border-subtle: rgba(8, 145, 178, 0.35);
+  --bs-success: #047857;
+  --bs-success-rgb: 4, 120, 87;
+  --bs-success-text-emphasis: #065F46;
+  --bs-success-bg-subtle: rgba(4, 120, 87, 0.10);
+  --bs-success-border-subtle: rgba(4, 120, 87, 0.35);
+  --bs-warning: #B45309;
+  --bs-warning-rgb: 180, 83, 9;
+  --bs-warning-text-emphasis: #92400E;
+  --bs-warning-bg-subtle: rgba(180, 83, 9, 0.10);
+  --bs-warning-border-subtle: rgba(180, 83, 9, 0.35);
+  --bs-danger: #DC2626;
+  --bs-danger-rgb: 220, 38, 38;
+  --bs-danger-text-emphasis: #991B1B;
+  --bs-danger-bg-subtle: rgba(220, 38, 38, 0.08);
+  --bs-danger-border-subtle: rgba(220, 38, 38, 0.35);
+  --bs-secondary: #64748B;
+  --bs-secondary-rgb: 100, 116, 139;
+  --bs-light: #FFFFFF;
+  --bs-light-rgb: 255, 255, 255;
+  --bs-dark: #0F172A;
+  --bs-dark-rgb: 15, 23, 42;
+}
+
+/* -------------------------------------------------------------
+   BASE
+   ------------------------------------------------------------- */
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 5.5rem;
+  background-color: var(--bs-body-bg);
+}
 body {
   max-width: 100%;
   overflow-x: hidden;
-  font-family: "Montserrat",system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue","Noto Sans","Liberation Sans",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !important;
+  padding-top: 4rem; /* fixed nav */
+  font-family: var(--font-mono) !important;
+  font-size: var(--bs-body-font-size);
+  line-height: var(--bs-body-line-height);
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
-details summary:after {
-  content: " (click to open)";
+::selection { background: var(--color-purple); color: #fff; }
+:focus-visible { outline: 2px solid var(--color-blue); outline-offset: 2px; }
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: var(--color-bg-deep); }
+::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 0; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-border-hover); }
+
+/* Scanlines overlay, same as ethcoordinate.org */
+.scanlines {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  background: repeating-linear-gradient(0deg, transparent 0px, transparent 2px, rgba(0,0,0,0.03) 2px, rgba(0,0,0,0.03) 4px);
 }
-details[open] summary:after {
-  content: " (click to close)";
+[data-bs-theme="light"] .scanlines {
+  background: repeating-linear-gradient(0deg, transparent 0px, transparent 2px, rgba(0,0,0,0.015) 2px, rgba(0,0,0,0.015) 4px);
+  opacity: 0.5;
 }
-details.nocomment summary:after,
-details[open].nocomment summary:after {
+
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 10000;
+  padding: 0.65rem 0.9rem;
+  color: var(--color-bg-void);
+  background: var(--color-blue);
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-decoration: none;
+  transform: translateY(-160%);
+  transition: transform 0.15s ease;
+}
+.skip-link:focus { transform: translateY(0); color: var(--color-bg-void); }
+
+/* -------------------------------------------------------------
+   TYPOGRAPHY
+   ------------------------------------------------------------- */
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+  color: var(--color-text-bright);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+h5, .h5, h6, .h6 { letter-spacing: -0.01em; }
+.display-1, .display-2, .display-3, .display-4, .display-5, .display-6 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+.display-4 { font-size: clamp(1.9rem, 4.5vw, 2.75rem); }
+.display-5 { font-size: clamp(1.75rem, 4vw, 2.4rem); }
+.display-6 { font-size: clamp(1.4rem, 3vw, 1.9rem); }
+.lead {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.8;
+  color: var(--color-text-body);
+}
+a { text-underline-offset: 3px; text-decoration-thickness: 1px; }
+code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  color: var(--bs-code-color);
+  background: var(--tint-purple);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+}
+pre code { background: transparent; padding: 0; color: inherit; }
+hr { border-color: var(--color-border); opacity: 1; }
+small, .small { color: inherit; }
+
+/* Eyebrow labels — tiny, tracked, uppercase */
+.eyebrow,
+.page-eyebrow,
+.hero-eyebrow {
+  display: block;
+  margin-bottom: 0.75rem;
+  color: var(--color-blue);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+.eyebrow--green { color: var(--coord-green); }
+.eyebrow--purple { color: var(--coord-purple); }
+.section-title {
+  font-size: clamp(1.6rem, 3.5vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text-bright);
+  margin-bottom: 0.75rem;
+}
+
+/* -------------------------------------------------------------
+   NAVIGATION — fixed bar with blurred backdrop
+   ------------------------------------------------------------- */
+.site-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1030;
+  height: 4rem;
+  padding: 0;
+  background: var(--nav-backdrop);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--color-border);
+  --bs-navbar-color: var(--color-text-muted);
+  --bs-navbar-hover-color: var(--color-text-bright);
+  --bs-navbar-active-color: var(--color-text-bright);
+  --bs-navbar-brand-color: var(--color-text-bright);
+  --bs-navbar-brand-hover-color: var(--color-text-bright);
+  --bs-navbar-toggler-border-color: transparent;
+  --bs-navbar-toggler-focus-width: 0;
+}
+.site-nav > .container {
+  height: 100%;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 1rem;
+}
+.brand-link {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0;
+  text-decoration: none;
+}
+.brand-logo {
+  --logo-h: 19px;
+  height: var(--logo-h);
+  width: auto;
+  display: block;
+  /* The wordmark SVG carries ~0.41×height of empty space on its left; pull it back so the
+     mark sits flush with the sub-label below it. */
+  margin-left: calc(var(--logo-h) * -0.41);
+}
+.brand-copy small {
+  display: block;
+  color: var(--color-text-muted);
+  font-size: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.site-nav .navbar-nav { gap: 0.35rem; }
+.site-nav .navbar-nav .nav-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: 4rem;
+}
+.site-nav .navbar-nav .nav-link {
+  padding: 0.5rem 0.5rem;
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: color 0.15s ease;
+}
+.site-nav .navbar-nav .nav-link:hover,
+.site-nav .navbar-nav .nav-link:focus-visible,
+.site-nav .navbar-nav .show > .nav-link,
+.site-nav .navbar-nav .nav-item:hover > .nav-link { color: var(--color-text-bright); }
+.site-nav .dropdown-toggle::after {
+  width: 7px;
+  height: 7px;
+  margin-left: 0.45rem;
+  border: 0;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg) translateY(-3px);
+  vertical-align: 0.15em;
+  opacity: 0.8;
+  transition: transform 0.15s ease;
+}
+.site-nav .show > .dropdown-toggle::after,
+.site-nav .nav-item:hover > .dropdown-toggle::after { transform: rotate(225deg) translateY(-3px); }
+
+.site-nav .dropdown-menu {
+  --bs-dropdown-min-width: 15rem;
+  --bs-dropdown-padding-x: 0.45rem;
+  --bs-dropdown-padding-y: 0.45rem;
+  --bs-dropdown-spacer: 0;
+  --bs-dropdown-font-size: 0.76rem;
+  --bs-dropdown-color: var(--color-text-bright);
+  --bs-dropdown-bg: color-mix(in srgb, var(--color-bg-elevated) 96%, transparent);
+  --bs-dropdown-border-color: var(--color-border);
+  --bs-dropdown-border-radius: 7px;
+  --bs-dropdown-link-color: var(--color-text-bright);
+  --bs-dropdown-link-hover-color: var(--color-text-bright);
+  --bs-dropdown-link-hover-bg: var(--tint-blue);
+  --bs-dropdown-link-active-color: var(--color-text-bright);
+  --bs-dropdown-link-active-bg: var(--tint-blue-strong);
+  --bs-dropdown-item-padding-x: 0.75rem;
+  --bs-dropdown-item-padding-y: 0.6rem;
+  margin-top: 0;
+  box-shadow: var(--shadow-float);
+}
+.site-nav .dropdown-item {
+  border-left: 2px solid transparent;
+  border-radius: 3px;
+  font-weight: 600;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.site-nav .dropdown-item:hover,
+.site-nav .dropdown-item:focus-visible { border-left-color: var(--color-blue); }
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 36px;
+  padding: 0.45rem 0.85rem;
+  color: var(--color-bg-void);
+  background: var(--color-blue);
+  border: 1px solid var(--color-blue);
+  border-radius: 4px;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.nav-cta:hover,
+.nav-cta:focus-visible {
+  color: var(--color-bg-void);
+  box-shadow: 0 0 16px rgba(0, 212, 255, 0.25);
+  transform: translateY(-1px);
+}
+[data-bs-theme="light"] .nav-cta,
+[data-bs-theme="light"] .nav-cta:hover { color: #FFFFFF; }
+.nav-cta .icon { display: none; }
+
+.site-nav .navbar-toggler {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--color-text-muted);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.site-nav .navbar-toggler:hover,
+.site-nav .navbar-toggler:focus { color: var(--color-blue); border-color: var(--color-border); box-shadow: none; }
+.site-nav .navbar-toggler .icon-close { display: none; }
+.site-nav .navbar-toggler[aria-expanded="true"] .icon-open { display: none; }
+.site-nav .navbar-toggler[aria-expanded="true"] .icon-close { display: block; }
+
+/* Theme toggle */
+#darkModeToggle { margin: 0; padding: 0; display: flex; }
+#darkModeToggle button {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+#darkModeToggle button:hover { color: var(--color-blue); }
+#darkModeToggle svg { width: 18px; height: 18px; }
+.d-dark,
+.dark-mode .d-light { display: none !important; }
+.d-light,
+.dark-mode .d-dark { display: unset !important; }
+
+@media (min-width: 992px) {
+  .site-nav .navbar-toggler { display: none; }
+  .site-nav .nav-item.dropdown:hover > .dropdown-menu {
+    display: block;
+    animation: fadeSlideDown 0.15s ease-out;
+  }
+  .site-nav .dropdown-menu.show { animation: fadeSlideDown 0.15s ease-out; }
+  .site-nav .dropdown-menu { top: 100%; left: -0.5rem; }
+}
+@media (max-width: 991.98px) {
+  .site-nav .navbar-collapse {
+    position: fixed;
+    top: 4rem;
+    left: 0;
+    right: 0;
+    min-height: calc(100vh - 4rem);
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+    padding: 0.5rem max(1rem, 5vw) 2rem;
+    background: var(--color-bg-void);
+    border-bottom: 1px solid var(--color-border);
+    overscroll-behavior: contain;
+  }
+  .site-nav .navbar-nav { gap: 0; }
+  .site-nav .navbar-nav .nav-item {
+    display: block;
+    min-height: 0;
+    border-top: 1px solid var(--color-border);
+  }
+  .site-nav .navbar-nav .nav-link {
+    padding: 1rem 0;
+    font-size: 1.05rem;
+    font-weight: 650;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+  .site-nav .dropdown-toggle::after { float: right; margin-top: 0.6rem; }
+  .site-nav .dropdown-menu {
+    --bs-dropdown-bg: transparent;
+    --bs-dropdown-border-color: transparent;
+    --bs-dropdown-padding-x: 0;
+    --bs-dropdown-padding-y: 0;
+    --bs-dropdown-font-size: 0.9rem;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+    padding: 0 0 1rem;
+    box-shadow: none;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+  .site-nav .dropdown-menu:not(.show) { display: none; }
+  .site-nav .dropdown-item {
+    min-height: 56px;
+    display: flex;
+    align-items: center;
+    padding: 0.75rem;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border);
+    border-left-width: 1px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    white-space: normal;
+  }
+  .site-nav .dropdown-item:hover { border-color: var(--color-border-hover); }
+  .nav-cta--mobile { width: 100%; min-height: 48px; margin-top: 1.25rem; }
+}
+@media (max-width: 480px) {
+  .site-nav .dropdown-menu { grid-template-columns: 1fr; }
+  .brand-logo { --logo-h: 17px; }
+  .brand-copy small { font-size: 0.46rem; }
+}
+
+/* -------------------------------------------------------------
+   HERO (home) — mirrors the ethcoordinate.org hero + terminal
+   ------------------------------------------------------------- */
+.es-hero {
+  position: relative;
+  min-height: min(820px, calc(100vh - 4rem));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6rem 1rem 5rem;
+  text-align: center;
+  overflow: hidden;
+}
+.hero-bg-mark {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: clamp(260px, 55vw, 720px);
+  height: auto;
+  transform: translate(-50%, -50%);
+  opacity: 0.16;
+  pointer-events: none;
+  animation: hero-breathe 8s ease-in-out infinite;
+}
+[data-bs-theme="light"] .hero-bg-mark { filter: saturate(0.6) brightness(0.9); opacity: 0.1; }
+@keyframes hero-breathe {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -50%) scale(1.03); }
+}
+.hero-glow {
+  position: absolute;
+  top: 42%;
+  left: 50%;
+  width: min(800px, 100vw);
+  height: min(600px, 100vh);
+  transform: translate(-50%, -50%);
+  background: radial-gradient(ellipse, rgba(0,212,255,0.07) 0%, rgba(168,85,247,0.035) 40%, transparent 70%);
+  pointer-events: none;
+}
+[data-bs-theme="light"] .hero-glow {
+  background: radial-gradient(ellipse, rgba(8,145,178,0.08) 0%, rgba(109,40,217,0.04) 40%, transparent 70%);
+}
+.hero-inner { position: relative; z-index: 2; max-width: 880px; }
+.hero-title {
+  margin-bottom: 1.5rem;
+  font-size: clamp(2.75rem, 8vw, 5.2rem);
+  font-weight: 300;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--color-text-bright);
+}
+.hero-title strong { font-weight: 700; }
+.hero-lead {
+  max-width: 560px;
+  margin: 0 auto 2.75rem;
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--color-text-secondary);
+}
+.terminal {
+  max-width: 600px;
+  margin: 0 auto;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  overflow: hidden;
+  text-align: left;
+}
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border);
+}
+.terminal-dot { width: 8px; height: 8px; border-radius: 50%; }
+.terminal-dot.r { background: #FF5F57; }
+.terminal-dot.y { background: #FFBD2E; }
+.terminal-dot.g { background: #28CA41; }
+.terminal-title { margin-left: auto; font-size: 0.7rem; color: var(--color-text-muted); }
+.terminal-body { padding: 1rem; font-size: 0.875rem; }
+.t-line { display: flex; margin-bottom: 0.2rem; }
+.t-prompt { color: var(--color-purple); margin-right: 0.5rem; }
+.t-cmd { color: var(--color-text-bright); }
+.t-out { color: var(--color-text-muted); padding-left: 1.2rem; }
+.t-out a { color: var(--color-text-secondary); text-decoration: none; }
+.t-out a:hover { color: var(--color-blue); text-decoration: underline; }
+.cursor {
+  display: inline-block;
+  width: 7px;
+  height: 13px;
+  margin-left: 2px;
+  background: var(--color-blue);
+  vertical-align: middle;
+  animation: blink 1s step-end infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+@keyframes fadeSlideDown {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@media (max-width: 680px) {
+  .es-hero { min-height: auto; padding: 4.5rem 0.25rem 4rem; }
+}
+@media (max-width: 480px) {
+  .hero-lead { font-size: 0.92rem; }
+  .terminal-body { font-size: 0.75rem; }
+}
+
+/* -------------------------------------------------------------
+   SECTION DIVIDERS
+   ------------------------------------------------------------- */
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 3rem 0 1.5rem;
+}
+.divider-line {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, var(--color-border), transparent);
+}
+.divider-line:last-child { background: linear-gradient(90deg, transparent, var(--color-border)); }
+.divider-text {
+  font-size: clamp(1.25rem, 4vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text-bright);
+}
+.divider-icons .divider { padding: 2.5rem 0; }
+.divider-icons-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1.25rem 2rem;
+}
+.divider-icons img,
+.divider-icons svg {
+  height: 30px;
+  width: auto;
+  display: inline-block;
+  opacity: 0.28;
+  filter: brightness(0) invert(1);
+  transition: opacity 0.2s ease;
+}
+[data-bs-theme="light"] .divider-icons img,
+[data-bs-theme="light"] .divider-icons svg {
+  opacity: 0.3;
+  filter: brightness(0);
+}
+.divider-icons img:hover,
+.divider-icons svg:hover { opacity: 0.6; }
+@media (max-width: 640px) {
+  .divider-icons img,
+  .divider-icons svg { height: 22px; }
+}
+
+/* -------------------------------------------------------------
+   CARDS
+   ------------------------------------------------------------- */
+.card {
+  --bs-card-bg: var(--color-bg-surface);
+  --bs-card-color: var(--color-text-body);
+  --bs-card-title-color: var(--color-text-bright);
+  --bs-card-subtitle-color: var(--color-text-muted);
+  --bs-card-border-color: var(--color-border);
+  --bs-card-border-radius: 8px;
+  --bs-card-inner-border-radius: 7px;
+  --bs-card-cap-bg: var(--color-bg-elevated);
+  --bs-card-cap-color: var(--color-text-bright);
+  position: relative;
+  border-radius: 8px;
+  transition: border-color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
+}
+.card::before {
   content: "";
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  right: -1px;
+  z-index: 1;
+  height: 2px;
+  border-radius: 8px 8px 0 0;
+  background: linear-gradient(90deg, var(--color-blue), var(--color-purple));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
 }
-section li:not(:last-child) {
-  margin-bottom: 0.25rem;
+.card.border-light,
+.card.border-0 { --bs-card-border-color: var(--color-border); }
+.card:hover:not(.shadow-0),
+.shadow-xl {
+  border-color: var(--color-border-hover);
+  box-shadow: 0 10px 40px var(--glow-blue) !important;
+}
+.card:has(.stretched-link):hover { transform: translateY(-2px); }
+.card:has(.stretched-link):hover::before { opacity: 1; }
+.card:has(.stretched-link):active { transform: scale(0.98); }
+.card .card-title { color: var(--color-text-bright); font-weight: 700; }
+.card .text-dark .card-title,
+.card .text-dark .card-text { color: inherit; }
+.card .card-date { color: var(--color-text-muted); }
+.card-img-top { border-bottom: 1px solid var(--color-border); }
+.card-tag {
+  display: inline-block;
+  padding: 0.2rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--color-purple);
+  background: var(--tint-purple);
+  white-space: nowrap;
 }
 
-
-
-/* buttons */
-.btn svg {
-  margin-top: -0.25rem;
+/* -------------------------------------------------------------
+   BUTTONS
+   ------------------------------------------------------------- */
+.btn {
+  --bs-btn-font-family: var(--font-mono);
+  --bs-btn-font-size: 0.8rem;
+  --bs-btn-font-weight: 500;
+  --bs-btn-line-height: 1.4;
+  --bs-btn-padding-y: 0.6rem;
+  --bs-btn-padding-x: 1.25rem;
+  --bs-btn-border-radius: 4px;
+  --bs-btn-focus-box-shadow: 0 0 0 0.25rem var(--tint-blue-strong);
+  letter-spacing: 0.01em;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
 }
-.dark-mode .btn-dark:not(.ignore) {
-  --bs-btn-color: var(--bs-body-bg);
-  --bs-btn-bg: var(--bs-gray-100);
-  --bs-btn-border-color: var(--bs-gray-100);
-  --bs-btn-hover-color: var(--bs-body-bg);
-  --bs-btn-hover-bg: var(--bs-gray-300);
-  --bs-btn-hover-border-color: var(--bs-gray-300);
-  --bs-btn-active-color: var(--bs-body-bg);
-  --bs-btn-active-bg: var(--bs-gray-300);
-  --bs-btn-active-border-color: var(--bs-gray-300);
-  --bs-btn-disabled-color: var(--bs-body-bg);
-  --bs-btn-disabled-bg: var(--bs-gray-300);
-  --bs-btn-disabled-border-color: var(--bs-gray-300);
+.btn-lg, .btn-group-lg > .btn {
+  --bs-btn-font-size: 0.9rem;
+  --bs-btn-padding-y: 0.75rem;
+  --bs-btn-padding-x: 1.5rem;
+  --bs-btn-border-radius: 5px;
 }
-.dark-mode .btn-outline-dark:not(.ignore) {
-  --bs-btn-color: var(--bs-gray-100);
-  --bs-btn-border-color: var(--bs-gray-100);
-  --bs-btn-hover-color: var(--bs-body-bg);
-  --bs-btn-hover-bg: var(--bs-gray-100);
-  --bs-btn-hover-border-color: var(--bs-gray-100);
-  --bs-btn-active-color: var(--bs-body-bg);
-  --bs-btn-active-bg: var(--bs-gray-100);
-  --bs-btn-active-border-color: var(--bs-gray-100);
-  --bs-btn-disabled-color: var(--bs-gray-100);
-  --bs-btn-disabled-border-color: var(--bs-gray-100);
+.btn-sm, .btn-group-sm > .btn {
+  --bs-btn-font-size: 0.72rem;
+  --bs-btn-padding-y: 0.4rem;
+  --bs-btn-padding-x: 0.85rem;
+  --bs-btn-border-radius: 4px;
+}
+.btn svg { margin-top: -0.2rem; }
+.btn:active { transform: scale(0.97); }
+
+/* Filled cyan — primary action */
+.btn-dark,
+.btn-primary {
+  --bs-btn-color: var(--color-bg-void);
+  --bs-btn-bg: var(--color-blue);
+  --bs-btn-border-color: var(--color-blue);
+  --bs-btn-hover-color: var(--color-bg-void);
+  --bs-btn-hover-bg: var(--color-blue-light);
+  --bs-btn-hover-border-color: var(--color-blue-light);
+  --bs-btn-active-color: var(--color-bg-void);
+  --bs-btn-active-bg: var(--color-blue-light);
+  --bs-btn-active-border-color: var(--color-blue-light);
+  --bs-btn-disabled-color: var(--color-bg-void);
+  --bs-btn-disabled-bg: var(--color-blue-muted);
+  --bs-btn-disabled-border-color: var(--color-blue-muted);
+  font-weight: 600;
+}
+.btn-dark:hover,
+.btn-primary:hover { box-shadow: 0 0 16px rgba(0, 212, 255, 0.25); }
+[data-bs-theme="light"] .btn-dark,
+[data-bs-theme="light"] .btn-primary {
+  --bs-btn-color: #FFFFFF;
+  --bs-btn-hover-color: #FFFFFF;
+  --bs-btn-active-color: #FFFFFF;
+  --bs-btn-disabled-color: #FFFFFF;
 }
 
-
-
-/* inputs, chechboxes, and radios */
-.btn,
-.btn-check {
-
+/* Outlined cyan — the ethcoordinate.org "card-btn" */
+.btn-outline-dark,
+.btn-outline-primary,
+.btn-outline-secondary,
+.btn-outline-light {
+  --bs-btn-color: var(--color-blue);
+  --bs-btn-bg: var(--tint-blue);
+  --bs-btn-border-color: var(--color-blue);
+  --bs-btn-hover-color: var(--color-blue);
+  --bs-btn-hover-bg: var(--tint-blue-strong);
+  --bs-btn-hover-border-color: var(--color-blue);
+  --bs-btn-active-color: var(--color-blue);
+  --bs-btn-active-bg: var(--tint-blue-strong);
+  --bs-btn-active-border-color: var(--color-blue);
+  --bs-btn-disabled-color: var(--color-blue-muted);
+  --bs-btn-disabled-border-color: var(--color-blue-muted);
 }
-.btn-check+.btn:hover,
-.btn:hover {
-  
+.btn-outline-dark:hover,
+.btn-outline-primary:hover,
+.btn-outline-secondary:hover,
+.btn-outline-light:hover { box-shadow: 0 0 16px rgba(0, 212, 255, 0.1); }
+[data-bs-theme="light"] .btn-outline-dark,
+[data-bs-theme="light"] .btn-outline-primary,
+[data-bs-theme="light"] .btn-outline-secondary,
+[data-bs-theme="light"] .btn-outline-light {
+  --bs-btn-color: #006A83;
+  --bs-btn-bg: #BBE9FF;
+  --bs-btn-border-color: #00CDFF;
+  --bs-btn-hover-color: #006A83;
+  --bs-btn-hover-bg: #A0DFFF;
+  --bs-btn-hover-border-color: #00B8E6;
+  --bs-btn-active-color: #006A83;
+  --bs-btn-active-bg: #A0DFFF;
+  --bs-btn-active-border-color: #00B8E6;
 }
-.btn-check:checked+.btn,
-.btn.active,
-.btn.show,
-.btn:first-child:active,
-:not(.btn-check)+.btn:active {
-  
+[data-bs-theme="light"] .btn-outline-dark:hover,
+[data-bs-theme="light"] .btn-outline-primary:hover { box-shadow: 0 2px 8px rgba(0, 205, 255, 0.25); }
+
+.btn-success {
+  --bs-btn-color: var(--color-bg-void);
+  --bs-btn-bg: var(--coord-green);
+  --bs-btn-border-color: var(--coord-green);
+  --bs-btn-hover-color: var(--color-bg-void);
+  --bs-btn-hover-bg: #6EE7B7;
+  --bs-btn-hover-border-color: #6EE7B7;
+  --bs-btn-active-bg: #6EE7B7;
+  --bs-btn-active-border-color: #6EE7B7;
 }
-.btn-check:active+.btn:focus,
-.btn-check:checked+.btn:focus,
-.btn.active:focus,
-.btn.dropdown-toggle.show:focus,
-.btn:active:focus,
-.btn-check:focus+.btn,
-.btn:focus {
-  box-shadow: var(--brand-shadow-1) var(--brand-color-1) !important;
+.btn-warning,
+.btn-devconnect {
+  --bs-btn-color: #1a1200;
+  --bs-btn-bg: var(--coord-yellow);
+  --bs-btn-border-color: var(--coord-yellow);
+  --bs-btn-hover-color: #1a1200;
+  --bs-btn-hover-bg: #FCD34D;
+  --bs-btn-hover-border-color: #FCD34D;
+  --bs-btn-active-bg: #FCD34D;
+  --bs-btn-active-border-color: #FCD34D;
+}
+.btn-secondary,
+.btn-light {
+  --bs-btn-color: var(--color-text-bright);
+  --bs-btn-bg: var(--color-bg-elevated);
+  --bs-btn-border-color: var(--color-border);
+  --bs-btn-hover-color: var(--color-text-bright);
+  --bs-btn-hover-bg: var(--color-bg-elevated);
+  --bs-btn-hover-border-color: var(--color-border-hover);
+  --bs-btn-active-bg: var(--color-bg-elevated);
+  --bs-btn-active-border-color: var(--color-border-hover);
 }
 .btn.disabled,
 .btn:disabled {
   cursor: not-allowed;
   opacity: 0.4 !important;
 }
+.btn-close { --bs-btn-close-opacity: 0.6; }
+
+/* -------------------------------------------------------------
+   FORMS
+   ------------------------------------------------------------- */
+.form-control,
+.form-select,
+.form-control:focus,
+.form-select:focus {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--color-text-bright);
+  background-color: var(--color-bg-surface);
+  border-color: var(--color-border);
+  border-radius: 4px;
+}
+.form-control::placeholder { color: var(--color-text-muted); }
+.form-control:focus,
+.form-control:active,
+.form-select:focus {
+  border-color: var(--color-blue);
+  box-shadow: 0 0 0 0.25rem var(--tint-blue-strong);
+  outline: 0;
+}
+.form-check-input {
+  background-color: var(--color-bg-surface);
+  border-color: var(--color-border);
+}
 .form-check-input:checked {
-  
+  background-color: var(--color-blue);
+  border-color: var(--color-blue);
 }
 .form-check-input:focus,
 .form-check-input:active {
-  box-shadow: 0 0 0 0.25rem var(--brand-color-1);
+  border-color: var(--color-blue);
+  box-shadow: 0 0 0 0.25rem var(--tint-blue-strong);
   outline: 0;
 }
-.form-control:focus,
-.form-control:active {
-  border-color: var(--bs-gray-300);
-  box-shadow: 0 0 0 0.25rem var(--brand-color-1);
-  outline: 0;
-}
-.form-control,
-.form-control:focus {
-  
-}
-.toggle-switch .toggle-switch-outline {
-  border: 1px solid rgba(var(--bs-body-color-rgb),0.4);
-}
-.toggle-switch :not(.btn-check:checked)+.btn-outline-primary {
-  --bs-btn-color: var(--bs-body-color);
+.form-label { color: var(--color-text-bright); font-size: 0.85rem; font-weight: 600; }
+.form-text { color: var(--color-text-muted); }
+
+/* Quiz toggle switch (kept from the previous theme, retokened) */
+.btn-check:active + .btn:focus,
+.btn-check:checked + .btn:focus,
+.btn.active:focus,
+.btn.dropdown-toggle.show:focus,
+.btn:active:focus,
+.btn-check:focus + .btn,
+.btn:focus { box-shadow: 0 0 0 0.25rem var(--tint-blue-strong) !important; }
+.toggle-switch .toggle-switch-outline { border: 1px solid var(--color-border); border-radius: 5px; }
+.toggle-switch :not(.btn-check:checked) + .btn-outline-primary {
+  --bs-btn-color: var(--color-text-body);
+  --bs-btn-bg: transparent;
   --bs-btn-border-color: transparent;
-  --bs-btn-hover-color: transparent;
+  --bs-btn-hover-color: var(--color-text-bright);
   --bs-btn-hover-bg: transparent;
   --bs-btn-hover-border-color: transparent;
-  --bs-btn-active-color: var(--bs-body-color);
+  --bs-btn-active-color: var(--color-text-body);
   --bs-btn-active-bg: transparent;
   --bs-btn-active-border-color: transparent;
-  --bs-btn-disabled-color: var(--bs-light);
+  --bs-btn-disabled-color: var(--color-text-muted);
   --bs-btn-disabled-border-color: transparent;
-  opacity: 60%;
+  opacity: 0.6;
 }
-.toggle-switch .btn-check:checked+.btn:focus,
-.toggle-switch .btn-check:checked+.btn:active,
-.toggle-switch .btn-check:focus+.btn {
-  box-shadow: none !important;
-}
+.toggle-switch .btn-check:checked + .btn:focus,
+.toggle-switch .btn-check:checked + .btn:active,
+.toggle-switch .btn-check:focus + .btn { box-shadow: none !important; }
 
-
-
-.card {
-  border-radius: 0.5rem;
-  transition: box-shadow 0.15s;
+/* -------------------------------------------------------------
+   TABLES, TABS, BADGES, TOOLTIPS, TOASTS, ALERTS
+   ------------------------------------------------------------- */
+.table {
+  --bs-table-bg: transparent;
+  --bs-table-color: var(--color-text-body);
+  --bs-table-border-color: var(--color-border);
+  --bs-table-striped-bg: rgba(0, 212, 255, 0.03);
+  --bs-table-striped-color: var(--color-text-body);
+  --bs-table-hover-bg: var(--tint-blue);
+  --bs-table-hover-color: var(--color-text-bright);
+  --bs-table-active-bg: var(--tint-blue-strong);
+  font-size: 0.875rem;
 }
-.card:hover:not(.shadow-0),
-.shadow-xl {
-  box-shadow: 0 1rem 3rem rgba(0,0,0,.25)!important;
+.table > thead th,
+.table > thead td {
+  color: var(--color-text-bright);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
-.dark-mode .card:hover:not(.shadow-0) {
-  box-shadow: 0 1rem 3rem rgba(0,0,0,.75)!important;
-}
-
-
-.table-responsive {
-  border-radius: var(--bs-border-radius);
-}
-.table-responsive .table {
-  margin-bottom: 0;
-}
+.table-responsive { border-radius: var(--bs-border-radius); }
+.table-responsive .table { margin-bottom: 0; }
 table tr td {
   max-width: 60vw !important;
   text-wrap: unset;
   word-wrap: break-word;
 }
 
-
-
-/* tabbed panels */
 .nav-tabs {
   border: none;
   padding-left: 5px;
   padding-right: 5px;
+  gap: 0.25rem;
 }
 .nav-tabs .nav-item {
   border: 3px solid transparent;
@@ -261,52 +1094,359 @@ table tr td {
 }
 .nav-tabs .nav-link {
   width: 100%;
-  --bs-border-opacity: 0.225;
-  border-color: rgba(var(--bs-secondary-rgb),var(--bs-border-opacity))!important;
-  border-bottom: none;
-  color: inherit;
+  color: var(--color-text-muted);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border) !important;
+  border-bottom: none !important;
+  border-radius: 6px 6px 0 0;
+  font-size: 0.8rem;
+  font-weight: 600;
   padding-bottom: 5px;
 }
 .nav-tabs .nav-item.show .nav-link,
 .nav-tabs .nav-link.active,
 .nav-tabs .nav-link:hover {
-  background-color: var(--soe-accent-blue);
+  color: var(--color-text-bright);
+  background-color: var(--color-bg-elevated);
+  box-shadow: inset 0 2px 0 var(--color-blue);
 }
 .tab-content {
-  border: 1px solid var(--bs-border-color);
+  border: 1px solid var(--color-border);
   border-radius: var(--bs-border-radius);
+  background: var(--color-bg-surface);
   padding: 1rem;
   padding-top: 1.5rem;
 }
 
+.badge {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border-radius: 3px;
+}
+.badge.rounded-pill { border-radius: 50rem; }
 
+.tooltip {
+  --bs-tooltip-bg: var(--color-bg-elevated);
+  --bs-tooltip-color: var(--color-text-bright);
+  --bs-tooltip-border-radius: 4px;
+  --bs-tooltip-font-size: 0.72rem;
+  --bs-tooltip-opacity: 1;
+  font-family: var(--font-mono);
+}
+.tooltip-inner { border: 1px solid var(--color-border); }
+
+.toast {
+  --bs-toast-bg: var(--color-bg-elevated);
+  --bs-toast-color: var(--color-text-body);
+  --bs-toast-border-color: var(--color-border);
+  --bs-toast-border-radius: 7px;
+  --bs-toast-header-bg: var(--color-bg-surface);
+  --bs-toast-header-color: var(--color-text-bright);
+  --bs-toast-header-border-color: var(--color-border);
+  --bs-toast-font-size: 0.82rem;
+  box-shadow: var(--shadow-float);
+}
+
+.alert {
+  --bs-alert-border-radius: 6px;
+  font-size: 0.875rem;
+}
+.bd-callout { font-size: 0.9rem; }
+
+/* -------------------------------------------------------------
+   NOTIFICATION BAR, CONTRIBUTE CTA
+   ------------------------------------------------------------- */
+#notification {
+  /* In-flow bar directly under the fixed nav (body carries the nav offset) */
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  color: var(--color-text-bright);
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.8rem;
+  text-align: center;
+}
+#notification::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--color-blue), var(--color-purple));
+}
+#notification a { color: var(--color-blue); font-weight: 600; }
+#notification a:hover { color: var(--color-blue-light); }
+#notificationClose {
+  cursor: pointer;
+  color: var(--color-text-muted);
+  transition: color 0.15s ease;
+}
+#notificationClose:hover { color: var(--color-text-bright); }
+
+#contributeCTA {
+  position: fixed;
+  z-index: 1035;
+  bottom: 2rem;
+  right: 1.5rem;
+  --bs-btn-color: var(--color-text-muted);
+  --bs-btn-bg: var(--color-bg-elevated);
+  --bs-btn-border-color: var(--color-border);
+  --bs-btn-hover-color: var(--color-blue);
+  --bs-btn-hover-bg: var(--color-bg-elevated);
+  --bs-btn-hover-border-color: var(--color-blue);
+  --bs-btn-active-color: var(--color-blue);
+  --bs-btn-active-bg: var(--color-bg-elevated);
+  --bs-btn-active-border-color: var(--color-blue);
+  --bs-btn-font-size: 0.72rem;
+  --bs-btn-padding-y: 0.45rem;
+  --bs-btn-padding-x: 0.9rem;
+  font-weight: 600;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35) !important;
+}
+#contributeCTA span { display: none; }
+#contributeCTA svg { font-size: 1.1rem; margin-top: -0.15rem; }
+@media only screen and (max-width: 767px) {
+  #contributeCTA { bottom: 1rem; right: 1rem; }
+  #contributeCTA svg { font-size: 1rem; }
+}
+
+/* -------------------------------------------------------------
+   PAGE HEADER (markdown layout)
+   ------------------------------------------------------------- */
+.page-header { padding: 3.5rem 0 0; }
+.page-title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text-bright);
+  margin-bottom: 0;
+}
+.page-desc {
+  max-width: 640px;
+  margin-top: 1rem;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--color-text-body);
+}
+.page-desc p:last-child { margin-bottom: 0; }
+.page-note { margin-top: 0.75rem; font-size: 0.8rem; color: var(--color-text-muted); }
+.page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+.page-actions .btn { margin: 0; }
+.page-divider {
+  height: 1px;
+  margin: 2.5rem 0 0;
+  background: linear-gradient(90deg, var(--color-border), transparent);
+}
+.markdown-header .btn.new-tab span.icon { display: none; }
+
+/* -------------------------------------------------------------
+   FOOTER — expanded, mirrors ethcoordinate.org
+   ------------------------------------------------------------- */
+.site-footer {
+  margin-top: 6rem;
+  padding: 3rem 0 2rem;
+  border-top: 1px solid var(--color-border);
+}
+.footer-main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 3rem;
+}
+.footer-brand {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  flex: 0 0 auto;
+  max-width: 280px;
+}
+.footer-brand .footer-logo img {
+  --logo-h: 26px;
+  height: var(--logo-h);
+  width: auto;
+  margin-left: calc(var(--logo-h) * -0.41); /* same left-padding trim as .brand-logo */
+}
+.footer-brand p {
+  margin: 0.9rem 0 0.5rem;
+  color: var(--color-text-body);
+  font-size: 0.78rem;
+}
+.footer-brand .footer-parent {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-text-body);
+}
+.footer-parent a {
+  color: var(--color-text-bright);
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid var(--coord-green);
+  transition: color 0.2s ease;
+}
+.footer-parent a:hover { color: var(--coord-green); }
+.footer-parent .icon { display: none; }
+.footer-mail {
+  margin-top: 1rem;
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+.footer-mail:hover { color: var(--color-blue); }
+.footer-nav-groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem 3rem;
+}
+.footer-nav-groups nav {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.55rem;
+}
+.footer-nav-groups nav > span {
+  margin-bottom: 0.25rem;
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.footer-nav-groups a {
+  color: var(--color-text-secondary);
+  font-size: 0.72rem;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+.footer-nav-groups a:hover { color: var(--color-blue); }
+.footer-nav-groups .new-tab span.icon { display: none; }
+.footer-disclaimer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  line-height: 1.65;
+}
+.footer-disclaimer p { margin-bottom: 0.6rem; }
+.footer-disclaimer p:last-child { margin-bottom: 0; }
+.footer-disclaimer strong { color: var(--color-text-body); }
+.footer-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border);
+}
+.footer-bottom > span { color: var(--color-text-muted); font-size: 0.62rem; }
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 1.5rem;
+}
+.footer-links a {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0.5rem 0;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+.footer-links a:hover { color: var(--color-blue); }
+.footer-links a:active { opacity: 0.7; }
+.footer-links .new-tab span.icon,
+.footer-socials .new-tab span.icon { display: none; }
+@media (max-width: 767.98px) {
+  .footer-main { flex-direction: column; gap: 2.5rem; }
+  .footer-brand { max-width: none; }
+  .footer-nav-groups { width: 100%; justify-content: space-between; gap: 2rem; }
+  .footer-bottom { align-items: flex-start; flex-direction: column-reverse; }
+}
+@media (max-width: 480px) {
+  .footer-nav-groups { flex-direction: column; }
+  .footer-links { gap: 0 1rem; }
+}
+
+/* -------------------------------------------------------------
+   LEGACY UTILITIES (kept for existing partials)
+   ------------------------------------------------------------- */
+.bg-tertiary { background-color: var(--bs-tertiary-bg); }
+.bg-light { background-color: var(--color-bg-surface) !important; }
+.border-light { border-color: var(--color-border) !important; }
+.brand-color-1 { color: var(--brand-color-1); }
+.bg-brand-color-1 { background-color: var(--brand-color-1); }
+.brand-color-2 { color: var(--brand-color-2); }
+.bg-brand-color-2 { background-color: var(--brand-color-2); }
+.brand-color-3 { color: var(--brand-color-3); }
+.bg-brand-color-3 { background-color: var(--brand-color-3); }
+.brand-color-4 { color: var(--brand-color-4); }
+.bg-brand-color-4 { background-color: var(--brand-color-4); }
+.brand-gradient-1 {
+  background: linear-gradient(45deg, rgba(var(--brand-color-2-rgb),1) 0%, rgba(var(--brand-color-3-rgb),1) 100%);
+}
+.brand-gradient-2 {
+  background: linear-gradient(to top, rgba(var(--bs-body-bg-rgb),1) 70%, rgba(var(--bs-body-bg-rgb),0) 100%) !important;
+}
+.brand-gradient-3 {
+  background: linear-gradient(to top, rgba(var(--brand-color-2-rgb),0) 0%,
+                                      rgba(var(--brand-color-2-rgb),0.08) 30%,
+                                      rgba(var(--brand-color-2-rgb),0.08) 70%,
+                                      rgba(var(--brand-color-2-rgb),0) 100%) !important;
+}
+.brand-gradient-4 {
+  background: linear-gradient(to top, rgba(var(--brand-color-2-rgb),0) 0%,
+                                      rgba(var(--brand-color-2-rgb),0.08) 10%,
+                                      rgba(var(--brand-color-2-rgb),0.08) 90%,
+                                      rgba(var(--brand-color-2-rgb),0) 100%) !important;
+}
+.brand-gradient-5 {
+  background: linear-gradient(to top, rgba(var(--brand-color-2-rgb),0) 0%,
+                                      rgba(var(--brand-color-2-rgb),0.08) 40%,
+                                      rgba(var(--brand-color-2-rgb),0.08) 60%,
+                                      rgba(var(--brand-color-2-rgb),0) 100%) !important;
+}
+
+details summary:after { content: " (click to open)"; color: var(--color-text-muted); font-size: 0.8em; }
+details[open] summary:after { content: " (click to close)"; }
+details.nocomment summary:after,
+details[open].nocomment summary:after { content: ""; }
+section li:not(:last-child) { margin-bottom: 0.25rem; }
 
 .link-disabled {
   cursor: not-allowed;
   opacity: 0.5;
   color: currentColor;
-  display: inline-block;  /* For IE11/ MS Edge bug */
+  display: inline-block;
   pointer-events: none;
   text-decoration: none;
 }
 
-
-
 /* hides the link new-tab icon */
+.brand-link span.icon,
+.nav-cta span.icon,
 .nav-item.dropdown .new-tab span.icon,
 .markdown-header .btn.new-tab span.icon,
-.footer-socials .new-tab span.icon,
 .branding-card .new-tab span.icon,
 .steward .new-tab span.icon,
 #sponsors .new-tab span.icon,
 .documenter .new-tab span.icon,
 .img-link span.icon,
 img .new-tab span.icon,
-.no-new-tab-icon span.icon {
-  display: none;
-}
-
-
+.no-new-tab-icon span.icon { display: none; }
 
 .videowrapper {
   float: none;
@@ -316,6 +1456,10 @@ img .new-tab span.icon,
   padding-bottom: 56.25%;
   padding-top: 25px;
   height: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-bg-surface);
 }
 .videowrapper iframe {
   position: absolute;
@@ -325,27 +1469,34 @@ img .new-tab span.icon,
   height: 100%;
 }
 
-
-
-.floating-hover { 
+.floating-hover {
   animation-name: floating;
   animation-duration: 4s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
 }
 @keyframes floating {
-  0% { transform: translate(0,  0px); }
-  50%  { transform: translate(0, 15px); }
-  100%   { transform: translate(0, -0px); }   
+  0% { transform: translate(0, 0px); }
+  50% { transform: translate(0, 15px); }
+  100% { transform: translate(0, -0px); }
 }
 
-
-
-.etheralpha { 
+.etheralpha {
   display: block;
-  color: var(--bs-secondary-color);
+  color: var(--color-text-muted);
   text-align: center;
-  opacity: .75;
+  opacity: 0.75;
   margin-top: 3rem;
-  font-size: 1rem !important;
+  font-size: 0.9rem !important;
 }
+
+/* -------------------------------------------------------------
+   REDUCED MOTION
+   ------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .hero-bg-mark, .cursor, .floating-hover { animation: none !important; }
+  .card, .btn, .nav-cta { transition: none !important; }
+}
+
+/* Sticky footer: main fills the viewport on short pages */
+main#main-content { flex: 1 0 auto; }

--- a/assets/css/markdown.css
+++ b/assets/css/markdown.css
@@ -1,58 +1,81 @@
-.markdown,
-.markdown p,
-.markdown h1,
-.markdown h2,
-.markdown h3,
-.markdown h4,
+/* =============================================================
+   Long-form content (markdown layout) — EthCoordinate tokens
+   ============================================================= */
+
+.markdown { font-size: 0.95rem; }
+.markdown h1 { font-weight: 700; }
+.markdown h2 {
+  margin-top: 3rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 1.6rem;
+}
+.markdown h3 {
+  margin-top: 2.25rem;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+.markdown h4 {
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.05rem;
+}
 .markdown h5,
 .markdown h6 {
-  
-}
-.markdown h1 {
-  font-weight: 600;
-}
-.markdown h2 {
-  font-weight: 600;
-  margin-top: 2.5rem;
-  margin-bottom: 2rem;
-}
-.markdown h3, h4 {
-  margin-top: 2rem;
-  margin-bottom: 1rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
 }
 .markdown p {
-  font-size: 1.15rem;
+  font-size: 0.95rem;
+  line-height: 1.85;
+  color: var(--color-text-body);
 }
+.markdown strong { color: var(--color-text-bright); }
 .markdown a {
+  color: var(--color-blue);
   text-decoration: underline;
+  text-underline-offset: 3px;
 }
-.markdown hr {
-  margin: 3rem 0 1rem 0;
-}
+.markdown a:hover { color: var(--color-blue-light); }
+.markdown a.btn { color: var(--bs-btn-color); text-decoration: none; }
+.markdown a.btn:hover { color: var(--bs-btn-hover-color); }
+.markdown hr { margin: 3rem 0 1rem 0; }
+.markdown ul,
+.markdown ol { padding-left: 1.4rem; }
 .markdown li {
   margin-bottom: 0.5rem;
-  font-size: 1.1rem;
+  font-size: 0.95rem;
+  line-height: 1.75;
 }
+.markdown li::marker { color: var(--color-blue); }
 .markdown blockquote {
-  border-left: 0.25rem solid var(--bs-body-color);
-  padding-left: 1rem;
+  margin: 1.5rem 0;
+  padding: 0.9rem 1.15rem;
+  border-left: 2px solid var(--color-blue);
+  border-radius: 0 6px 6px 0;
+  background: var(--color-bg-surface);
+  color: var(--color-text-body);
 }
+.markdown blockquote p:last-child { margin-bottom: 0; }
 .markdown details {
   text-align: left;
   padding: 10px 20px;
-  border-radius: 5px;
+  border-radius: 6px;
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
-  background-color: var(--bs-body-bg);
-  /*from .border*/
-  border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
-  /*from .shadow-sm*/
-  box-shadow: 0 .125rem .25rem rgba(0,0,0,.075)!important;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border) !important;
+}
+.markdown details summary {
+  color: var(--color-text-bright);
+  font-weight: 600;
+  cursor: pointer;
 }
 .markdown details[open] summary {
   margin-bottom: 10px;
   padding-bottom: 10px;
-  border-bottom: solid 1px var(--bs-border-color);
+  border-bottom: solid 1px var(--color-border);
 }
 .markdown img {
   margin: 5px auto;
@@ -60,97 +83,90 @@
   height: auto;
   max-height: 350px;
   display: block;
+  border-radius: 6px;
 }
-.markdown p>img {
-  /*from .shadow*/
-  box-shadow: 0 .5rem 1rem rgba(0,0,0,.15)!important;
-}
+.markdown p > img { border: 1px solid var(--color-border); }
 .markdown .caption {
   display: block;
   text-align: center;
-  font-size: .875em;
-  padding-bottom: 1rem!important;
+  font-size: 0.8em;
+  color: var(--color-text-muted);
+  padding-bottom: 1rem !important;
 }
 .markdown table {
-  font-size: 1.05rem;
+  font-size: 0.875rem;
 
-  /*fallback from .table*/
-  --bs-table-color: var(--bs-body-color);
+  /* fallback from .table */
+  --bs-table-color: var(--color-text-body);
   --bs-table-bg: transparent;
-  --bs-table-border-color: var(--bs-border-color);
+  --bs-table-border-color: var(--color-border);
   --bs-table-accent-bg: transparent;
-  --bs-table-striped-color: var(--bs-body-color);
-  --bs-table-striped-bg: rgba(0, 0, 0, 0.05);
-  --bs-table-active-color: var(--bs-body-color);
-  --bs-table-active-bg: rgba(0, 0, 0, 0.1);
-  --bs-table-hover-color: var(--bs-body-color);
-  --bs-table-hover-bg: rgba(0, 0, 0, 0.075);
+  --bs-table-striped-color: var(--color-text-body);
+  --bs-table-striped-bg: rgba(0, 212, 255, 0.03);
+  --bs-table-active-color: var(--color-text-bright);
+  --bs-table-active-bg: var(--tint-blue-strong);
+  --bs-table-hover-color: var(--color-text-bright);
+  --bs-table-hover-bg: var(--tint-blue);
   width: 100%;
   margin-bottom: 1rem;
   color: var(--bs-table-color);
   vertical-align: top;
   border-color: var(--bs-table-border-color);
 
-  /*fallback from .mx-auto*/
-  margin-right: auto!important;
-  margin-left: auto!important;
+  /* fallback from .mx-auto */
+  margin-right: auto !important;
+  margin-left: auto !important;
 }
-.markdown .table>tbody>tr:nth-of-type(even)>* {
-  /*fallback from .table-striped*/
-  /*--bs-table-accent-bg: var(--bs-table-striped-bg);
-  color: var(--bs-table-striped-color);*/
-}
-.markdown table>thead {
-  background-color: var(--bs-body-bg);
+.markdown table > thead {
+  background-color: var(--color-bg-elevated);
 
-  /*fallback from .sticky-top*/
+  /* fallback from .sticky-top */
   position: sticky;
   top: -1px;
   z-index: 1020;
 }
-.markdown table>:not(:last-child)>:last-child>* {
-  
-}
-.table-bordered>:not(caption)>*{
+.table-bordered > :not(caption) > * {
   border-width: 1px 0;
 }
-.markdown table>:not(caption)>*>* {
+.markdown table > :not(caption) > * > * {
   padding: 0.5rem 0.5rem;
   background-color: var(--bs-table-bg);
   border-bottom-width: 1px;
   box-shadow: inset 0 0 0 9999px var(--bs-table-accent-bg);
 }
-.markdown table>tbody {
-
-}
 .markdown pre {
-  background-color: rgba(0, 0, 0, 1);
-  padding: 10px 15px;
-  border-radius: 0.5rem;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  overflow-x: auto;
 }
-.markdown pre code {
-  color: rgba(255, 255, 255, 0.9);
-}
+.markdown pre code { color: var(--color-text-secondary); }
 
 /* markdown header anchor link copy icon */
 .markdown .copy-link-icon {
-  color: var(--bs-secondary);
+  color: var(--color-text-muted);
   opacity: 0.6;
   cursor: pointer;
   position: absolute;
+  margin-left: 0.35rem;
+  transition: opacity 0.15s ease, color 0.15s ease;
 }
+.markdown .copy-link-icon:hover { opacity: 1; color: var(--color-blue); }
 .markdown .copy-link-icon > svg {
-  height: 2rem;
+  height: 1.5rem;
   width: auto;
 }
 
-
-/*adds sticky header*/
+/* adds sticky header */
 .markdown .table-responsive {
   max-height: 700px;
   overflow: scroll;
-  position: relative!important;
-  /*widens table*/
+  position: relative !important;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  /* widens table */
   margin-left: -250px !important;
   margin-right: -250px !important;
   margin-top: 1.5rem;
@@ -178,13 +194,13 @@
     max-height: 400px;
   }
 }
-/*adds sticks first column*/
+/* adds sticky first column */
 .markdown .table thead tr {
-  background-color: var(--bs-tertiary-bg);
+  background-color: var(--color-bg-elevated);
 }
 .markdown .table th:first-child,
 .markdown .table td:first-child {
   position: sticky;
   left: -1px;
-  background-color: var(--bs-tertiary-bg);
+  background-color: var(--color-bg-elevated);
 }


### PR DESCRIPTION
## What
Theme layer that restyles ethstaker.org to the [EthCoordinate](https://ethcoordinate.org) design system and presents the site as an EthCoordinate initiative. Jekyll, Bootstrap and the page content stay as they are; the look comes from remapped Bootstrap CSS variables plus a rebuilt nav, hero, footer and page header.

- **Tokens & type** — JetBrains Mono, cyan/purple accents on near-black, matching light palette. Cards, buttons, forms, tables, dropdowns, callouts and toasts are restyled through Bootstrap's own variables, so existing partials and utility classes keep working.
- **Dark by default** — pre-paint theme script; the OS light preference and the saved toggle (`localStorage.darkModeEnabled`) still win.
- **Nav** — fixed bar with the `EthStaker · An EthCoordinate initiative` lockup, hover dropdowns, "Start staking" CTA, mobile panel.
- **Home** — hero (eyebrow, "EthStaker", lead, status terminal), section eyebrows/titles, gradient dividers, fixed-width word slot in the staking section so nothing reflows.
- **Footer** — brand + "An initiative of EthCoordinate ↗", five link groups, disclaimer, © line with text social links.
- **Markdown pages** — eyebrow / title / divider header and long-form typography.

## Where
`assets/css/main.css` (rewritten: tokens, remaps, components), `assets/css/markdown.css`, `_layouts/default.html`, `_layouts/markdown.html`, `_includes/partials/components/{head,nav,footer,dark-mode-toggle,divider-icons-template,notification,contribute,toast}.html`, `_includes/partials/content/index/*.html`, `_includes/js/aos.js`, `README.md` (new Theme section), `_config_dev.yml` (dev notification off).

## Notes
- The notification bar renders in-flow under the fixed nav; the current production notice has expired, and it is switched off in `_config_dev.yml` for local previews.
- Checked 106 page loads at desktop/mobile in dark and light. Pre-existing and untouched: `/mev-relay-list` and `/smoothing-pools` inline-script errors, AOS pre-animation offsets.

## Screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
